### PR TITLE
Issues/#49 - Add ability to disable spoor via config.json.

### DIFF
--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -22,6 +22,7 @@ define(function(require) {
 
     initialize: function() {
       this.data = Adapt.config.get('_spoor');
+      if (this.data._isEnabled === false) return;
       this.SCOStart() ;
       $(window).unload(_.bind(this.SCOFinish, this));
       this.onDataReady();


### PR DESCRIPTION
Added the following code in the develop branch, as per @oliverfoster.
```javascript
if (this.data._isEnabled === false) return;
```

This should work for Adapt core.  For more complicated cases where scormWrapper gets called directly (from a component or extension), we should look at adding an _isEnabled variable in adapt-contrib-spoor.js so we don't have to continuously check *if ( this.data._isEnabled === false)* or *if ( this.data._isEnabled === true)*, as per @moloko.