### PR TITLE
Lukasz Grela - ScormWrapper settings externalised

### DIFF
--- a/example.json
+++ b/example.json
@@ -11,6 +11,15 @@
 			"_comment": "Your options here are 'completed', 'passed', 'failed', and 'incomplete'",
 			"_onTrackingCriteriaMet": "completed",
 			"_onAssessmentFailure": "incomplete"
-		}
+		},
+	        "_scormWrapper": {
+	            "setCompletedWhenFailed":true,
+	            "commitOnStatusChange":true,
+	            "disableInteractionTracking":false,
+	            "timedCommitFrequency":10,
+	            "maxCommitRetries":5,
+	            "commitRetryDelay":2000,
+	            "commitRetryPending":false
+	        }
 	}
 }

--- a/example.json
+++ b/example.json
@@ -12,12 +12,13 @@
 			"_onTrackingCriteriaMet": "completed",
 			"_onAssessmentFailure": "incomplete"
 		},
-	        "_advancedSettings": {
-	            "commitOnStatusChange":true,
-	            "disableInteractionTracking":false,
-	            "timedCommitFrequency":10,
-	            "maxCommitRetries":5,
-	            "commitRetryDelay":2000
-	        }
+		"_advancedSettings": {
+			"showDebug":true,
+			"commitOnStatusChange":true,
+			"disableInteractionTracking":false,
+			"timedCommitFrequency":10,
+			"maxCommitRetries":5,
+			"commitRetryDelay":2000
+		}
 	}
 }

--- a/example.json
+++ b/example.json
@@ -12,7 +12,7 @@
 			"_onTrackingCriteriaMet": "completed",
 			"_onAssessmentFailure": "incomplete"
 		},
-	        "_scormWrapper": {
+	        "_advancedSettings": {
 	            "setCompletedWhenFailed":true,
 	            "commitOnStatusChange":true,
 	            "disableInteractionTracking":false,

--- a/example.json
+++ b/example.json
@@ -18,8 +18,7 @@
 	            "disableInteractionTracking":false,
 	            "timedCommitFrequency":10,
 	            "maxCommitRetries":5,
-	            "commitRetryDelay":2000,
-	            "commitRetryPending":false
+	            "commitRetryDelay":2000
 	        }
 	}
 }

--- a/example.json
+++ b/example.json
@@ -13,7 +13,6 @@
 			"_onAssessmentFailure": "incomplete"
 		},
 	        "_advancedSettings": {
-	            "setCompletedWhenFailed":true,
 	            "commitOnStatusChange":true,
 	            "disableInteractionTracking":false,
 	            "timedCommitFrequency":10,

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -29,17 +29,17 @@ define(function(require) {
     },
 
     SCOStart: function() {
-		/**
-		* force use of SCORM 1.2 - as some LMSes (SABA, for instance) present both APIs to the SCO and, if given the choice, 
-		* the pipwerks code will automatically select the SCORM 2004 API - which can lead to unexpected behaviour.
-		* this does obviously mean you'll have to manually change (or just remove) this next line if you want SCORM 2004 output
-		*/
-		//TODO allow version to be set via config.json
+	/**
+	* force use of SCORM 1.2 - as some LMSes (SABA, for instance) present both APIs to the SCO and, if given the choice, 
+	* the pipwerks code will automatically select the SCORM 2004 API - which can lead to unexpected behaviour.
+	* this does obviously mean you'll have to manually change (or just remove) this next line if you want SCORM 2004 output
+	*/
+	//TODO allow version to be set via config.json
         scormWrapper.setVersion("1.2");
-
-		if (scormWrapper.initialize()) {
-			this.set('initialised', true);
-		}
+	var settings = this.data && this.data._scormWrapper ? this.data._scormWrapper:null;
+	if (scormWrapper.initialize(settings)) {
+		this.set('initialised', true);
+	}
     },
 
     SCOFinish: function() {

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -36,7 +36,7 @@ define(function(require) {
 	*/
 	//TODO allow version to be set via config.json
         scormWrapper.setVersion("1.2");
-	var settings = this.data && this.data._scormWrapper ? this.data._scormWrapper:null;
+	var settings = this.data && this.data._advancedSettings ? this.data._advancedSettings:null;
 	if (scormWrapper.initialize(settings)) {
 		this.set('initialised', true);
 	}

--- a/js/scormWrapper.js
+++ b/js/scormWrapper.js
@@ -105,6 +105,8 @@ define (function(require) {
 			if (settings.hasOwnProperty("timedCommitFrequency")) { this.timedCommitFrequency = settings.timedCommitFrequency; }
 			if (settings.hasOwnProperty("maxCommitRetries")) { this.maxCommitRetries = settings.maxCommitRetries; }
 			if (settings.hasOwnProperty("commitRetryDelay")) { this.commitRetryDelay = settings.commitRetryDelay; }
+            
+			if (settings.hasOwnProperty("showDebug") && settings.showDebug === true) { this.showDebugWindow(); }
 		}		
 		this.lmsConnected = this.scorm.init();
 

--- a/js/scormWrapper.js
+++ b/js/scormWrapper.js
@@ -105,7 +105,6 @@ define (function(require) {
 			if (settings.hasOwnProperty("timedCommitFrequency")) { this.timedCommitFrequency = settings.timedCommitFrequency; }
 			if (settings.hasOwnProperty("maxCommitRetries")) { this.maxCommitRetries = settings.maxCommitRetries; }
 			if (settings.hasOwnProperty("commitRetryDelay")) { this.commitRetryDelay = settings.commitRetryDelay; }
-			if (settings.hasOwnProperty("commitRetryPending")) { this.commitRetryPending = settings.commitRetryPending; }
 		}		
 		this.lmsConnected = this.scorm.init();
 

--- a/js/scormWrapper.js
+++ b/js/scormWrapper.js
@@ -97,7 +97,16 @@ define (function(require) {
 		}
 	};
 
-	ScormWrapper.prototype.initialize = function() {
+	ScormWrapper.prototype.initialize = function(settings) {
+		if (settings) {
+			if (settings.hasOwnProperty("setCompletedWhenFailed")) { this.setCompletedWhenFailed = settings.setCompletedWhenFailed; }
+			if (settings.hasOwnProperty("commitOnStatusChange")) { this.commitOnStatusChange = settings.commitOnStatusChange; }
+			if (settings.hasOwnProperty("disableInteractionTracking")) { this.disableInteractionTracking = settings.disableInteractionTracking; }
+			if (settings.hasOwnProperty("timedCommitFrequency")) { this.timedCommitFrequency = settings.timedCommitFrequency; }
+			if (settings.hasOwnProperty("maxCommitRetries")) { this.maxCommitRetries = settings.maxCommitRetries; }
+			if (settings.hasOwnProperty("commitRetryDelay")) { this.commitRetryDelay = settings.commitRetryDelay; }
+			if (settings.hasOwnProperty("commitRetryPending")) { this.commitRetryPending = settings.commitRetryPending; }
+		}		
 		this.lmsConnected = this.scorm.init();
 
 		if (this.lmsConnected) {

--- a/properties.schema
+++ b/properties.schema
@@ -91,6 +91,15 @@
                   "required":false,
                   "title": "Advanced Settings",
                   "properties":{
+                    "showDebug": {
+                      "type":"boolean",
+                      "required":false,
+                      "default":false,
+                      "title":"Show debug window",
+                      "inputType": {"type": "Boolean", "options": [true, false]},
+                      "validators": [],
+                      "help": "Whether to display debug window"
+                    },
                     "commitOnStatusChange": {
                       "type":"boolean",
                       "required":false,

--- a/properties.schema
+++ b/properties.schema
@@ -85,6 +85,58 @@
                       "help": ""
                     }
                   }
+                },
+                "_advancedSettings":{
+                  "type":"object",
+                  "required":false,
+                  "title": "Advanced Settings",
+                  "properties":{
+                    "commitOnStatusChange": {
+                      "type":"boolean",
+                      "required":false,
+                      "default":true,
+                      "title":"Commit on status change",
+                      "inputType": {"type": "Boolean", "options": [true, false]},
+                      "validators": [],
+                      "help": "Whether to commit each time there's a change to lesson_status or not"
+                    },
+                    "disableInteractionTracking": {
+                      "type":"boolean",
+                      "required":false,
+                      "default":false,
+                      "title":"Disable interaction tracking",
+                      "inputType": {"type": "Boolean", "options": [true, false]},
+                      "validators": [],
+                      "help": "Allows you to deactivate tracking to cmi.interactions - useful in instances where the code to detect when cmi.interactions are supported isn't working due to inconsistent LMS behaviour"
+                    },
+                    "timedCommitFrequency": {
+                      "type":"number",
+                      "required":false,
+                      "default":10,
+                      "title":"Frequency of commits",
+                      "inputType": "Number",
+                      "validators": ["number"],
+                      "help": "How frequently (in minutes) to commit automatically. Set to 0 to disable."
+                    },
+                    "maxCommitRetries": {
+                      "type":"number",
+                      "required":false,
+                      "default":5,
+                      "title":"Maximum commit retries",
+                      "inputType": "Number",
+                      "validators": ["number"],
+                      "help": "How many times to retry if a commit fails."
+                    },
+                    "commitRetryDelay": {
+                      "type":"number",
+                      "required":false,
+                      "default":1000,
+                      "title":"Delay between commit retries",
+                      "inputType": "Number",
+                      "validators": ["number"],
+                      "help": "Time (in milliseconds) to wait between retries."
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
Externalisation of the `ScormWrapper`'s settings, those settings are in the `config.json` in `_spoor` object under `_scormWrapper` object property.

	"_spoor": {
        "_scormWrapper": {
            "showDebug":true,
            "commitOnStatusChange":true,
            "disableInteractionTracking":false,
            "timedCommitFrequency":10,
            "maxCommitRetries":5,
            "commitRetryDelay":2000
        }
	}
