### PR TITLE
ABU-676: Extended scorm tracking to optionally include...

### DIFF
--- a/example.json
+++ b/example.json
@@ -5,7 +5,8 @@
 		"_tracking": {
 			"_requireCourseCompleted": true,
 			"_requireAssessmentPassed": false,
-			"_shouldSubmitScore": false
+			"_shouldSubmitScore": false,
+			"_shouldStoreQuestions": false
 		},
 		"_reporting": {
 			"_comment": "Your options here are 'completed', 'passed', 'failed', and 'incomplete'",

--- a/example.json
+++ b/example.json
@@ -6,7 +6,7 @@
 			"_requireCourseCompleted": true,
 			"_requireAssessmentPassed": false,
 			"_shouldSubmitScore": false,
-			"_shouldStoreQuestions": false
+			"_shouldStoreResponses": false
 		},
 		"_reporting": {
 			"_comment": "Your options here are 'completed', 'passed', 'failed', and 'incomplete'",

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -16,7 +16,7 @@ define([
 
 		_sessionID: null,
 		_config: null,
-		_shouldStoreQuestions: false,
+		_shouldStoreResponses: false,
 
 	//Session Begin
 		initialize: function() {
@@ -28,7 +28,7 @@ define([
 
 		getConfig: function() {
 			this._config = Adapt.config.get('_spoor');
-			this._shouldStoreQuestions = (this._config && this._config._tracking && this._config._tracking._shouldStoreQuestions);
+			this._shouldStoreResponses = (this._config && this._config._tracking && this._config._tracking._shouldStoreResponses);
 		},
 
 		checkSaveState: function() {
@@ -47,7 +47,7 @@ define([
 		restoreSessionState: function() {
 			var sessionPairs = Adapt.offlineStorage.get();
 
-			if (sessionPairs.questions && this._shouldStoreQuestions ) questions.deserialize(sessionPairs.questions);
+			if (sessionPairs.questions && this._shouldStoreResponses ) questions.deserialize(sessionPairs.questions);
 
 			if (sessionPairs.completion) serializer.deserialize(sessionPairs.completion);
 
@@ -59,7 +59,7 @@ define([
 		getSessionState: function() {
 			var sessionPairs = {
 				"completion": serializer.serialize(),
-				"questions": (this._shouldStoreQuestions == true ? questions.serialize() : ""),
+				"questions": (this._shouldStoreResponses == true ? questions.serialize() : ""),
 				"_isCourseComplete": Adapt.course.get("_isComplete") || false,
 				"_isAssessmentPassed": Adapt.course.get('_isAssessmentPassed') || false
 			};
@@ -75,7 +75,7 @@ define([
 			this._onWindowUnload = _.bind(this.onWindowUnload, this);
 			$(window).on('unload', this._onWindowUnload);
 
-			if (this._shouldStoreQuestions) {
+			if (this._shouldStoreResponses) {
 				this.listenTo(Adapt.components, 'change:_isInteractionComplete', this.onQuestionComponentComplete);
 			}
 

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -6,8 +6,9 @@
 
 define([
 	'coreJS/adapt',
-	'./serializers/default'
-], function(Adapt, serializer) {
+	'./serializers/default',
+	'./serializers/questions'
+], function(Adapt, serializer, questions) {
 
 	//Implements Adapt session statefulness
 	
@@ -15,6 +16,7 @@ define([
 
 		_sessionID: null,
 		_config: null,
+		_shouldStoreQuestions: false,
 
 	//Session Begin
 		initialize: function() {
@@ -26,6 +28,7 @@ define([
 
 		getConfig: function() {
 			this._config = Adapt.config.get('_spoor');
+			this._shouldStoreQuestions = (this._config && this._config._tracking && this._config._tracking._shouldStoreQuestions);
 		},
 
 		checkSaveState: function() {
@@ -44,8 +47,10 @@ define([
 		restoreSessionState: function() {
 			var sessionPairs = Adapt.offlineStorage.get();
 
+			if (sessionPairs.questions && this._shouldStoreQuestions ) questions.deserialize(sessionPairs.questions);
+
 			if (sessionPairs.completion) serializer.deserialize(sessionPairs.completion);
-			
+
 			if (sessionPairs._isCourseComplete) Adapt.course.set('_isComplete', sessionPairs._isCourseComplete);
 			
 			if (sessionPairs._isAssessmentPassed) Adapt.course.set('_isAssessmentPassed', sessionPairs._isAssessmentPassed);
@@ -54,6 +59,7 @@ define([
 		getSessionState: function() {
 			var sessionPairs = {
 				"completion": serializer.serialize(),
+				"questions": (this._shouldStoreQuestions == true ? questions.serialize() : ""),
 				"_isCourseComplete": Adapt.course.get("_isComplete") || false,
 				"_isAssessmentPassed": Adapt.course.get('_isAssessmentPassed') || false
 			};
@@ -69,6 +75,10 @@ define([
 			this._onWindowUnload = _.bind(this.onWindowUnload, this);
 			$(window).on('unload', this._onWindowUnload);
 
+			if (this._shouldStoreQuestions) {
+				this.listenTo(Adapt.components, 'change:_isInteractionComplete', this.onQuestionComponentComplete);
+			}
+
 			this.listenTo(Adapt.blocks, 'change:_isComplete', this.onBlockComplete);
 			this.listenTo(Adapt.course, 'change:_isComplete', this.onCompletion);
 			this.listenTo(Adapt, 'assessment:complete', this.onAssessmentComplete);
@@ -77,6 +87,11 @@ define([
 		},
 
 		onBlockComplete: function(block) {
+			this.saveSessionState();
+		},
+
+		onQuestionComponentComplete: function(component) {
+			if (!component.get("_isQuestionType")) return;
 			this.saveSessionState();
 		},
 

--- a/js/serializers/questions.js
+++ b/js/serializers/questions.js
@@ -1,0 +1,170 @@
+/*
+* adapt-contrib-spoor
+* License - http://github.com/adaptlearning/adapt_framework/LICENSE
+* Maintainers -  Oliver Foster <oliver.foster@kineo.com>
+*/
+
+define([
+    'coreJS/adapt',
+    './scormSuspendDataSerializer'
+], function (Adapt) {
+
+    //Captures the completion status and user selections of the question components
+    //Returns and parses a base64 style string
+
+    var serializer = {
+        serialize: function () {
+            return this.serializeSaveState();
+        },
+
+        serializeSaveState: function() {
+            if (Adapt.course.get('_latestTrackingId') === undefined) {
+                var message = "This course is missing a latestTrackingID.\n\nPlease run the grunt process prior to deploying this module on LMS.\n\nScorm tracking will not work correctly until this is done.";
+                console.error(message);
+                return "";
+            }
+
+            var rtn = "";
+            try {
+                var data = this.captureData();
+                console.log(data);
+                rtn = SCORMSuspendData.serialize(data);
+            } catch(e) {
+                console.error(e);
+            }
+
+            return rtn;
+        },
+
+        captureData: function() {
+            var data = [];
+            
+            var components = Adapt.components.toJSON();
+
+            var includes = {
+                "_isQuestionType": true,
+                "_isResetOnRevisit": false
+            };
+
+            components = _.where(components, includes);
+
+            var blocks = {};
+            var countInBlock = {};
+
+            for (var i = 0, l = components.length; i < l; i++) {
+                var component = components[i];
+                var blockId = component._parentId;
+
+                if (!blocks[blockId]) {
+                    blocks[blockId] = Adapt.findById(blockId).toJSON();
+                }
+
+                var block = blocks[blockId];
+                if (countInBlock[blockId] === undefined) countInBlock[blockId] = -1;
+                countInBlock[blockId]++;
+
+                var blockLocation = countInBlock[blockId];
+
+                if (component['_isInteractionComplete'] === false || component['_isComplete'] === false) {
+                    //if component is not currently complete skip it
+                    continue;
+                }
+
+                if (block['_trackingId'] === undefined) {
+                    //if block has no tracking id, skip it
+                    continue;
+                }
+
+                var hasUserAnswer = (component['_userAnswer'] !== undefined);
+                var isUserAnswerArray = (component['_userAnswer'] instanceof Array);
+
+
+                var trackingIdAndBlockLocation = [
+                        blockLocation,
+                        block['_trackingId']
+                    ];
+
+                var booleanParameters = [
+                        hasUserAnswer,
+                        isUserAnswerArray,
+                        component['_isInteractionComplete'],
+                        component['_isSubmitted']
+                    ];
+
+                var dataItem = [
+                    trackingIdAndBlockLocation,
+                    booleanParameters
+                ];
+
+
+                if (hasUserAnswer) {
+                    var userAnswer = isUserAnswerArray ? component['_userAnswer'] : [component['_userAnswer']];
+
+                    var arrayType = SCORMSuspendData.DataType.getArrayType(userAnswer);
+
+                    switch(arrayType.name) {
+                    case "string": case "variable":
+                        console.log("Cannot store _userAnswers from component " + component._id + " as array is of variable or string type.");
+                        continue;
+                    }
+
+                    dataItem.push(userAnswer);
+                }
+
+                data.push(dataItem);
+
+            }
+
+            return data;
+
+        },
+
+        deserialize: function (str) {
+
+            try {
+                var data = SCORMSuspendData.deserialize(str);
+                console.log(data);
+                this.releaseData( data );
+            } catch(e) {
+                console.error(e);
+            }
+            
+        },    
+
+        releaseData: function (arr) {
+            
+            for (var i = 0, l = arr.length; i < l; i++) {
+                var dataItem = arr[i];
+
+                var trackingIdAndBlockLocation = dataItem[0];
+                var booleanParameters = dataItem[1];
+
+                var blockLocation = trackingIdAndBlockLocation[0];
+                var trackingId = trackingIdAndBlockLocation[1];
+
+                var hasUserAnswer = booleanParameters[0];
+                var isUserAnswerArray = booleanParameters[1];
+                var isInteractionComplete = booleanParameters[2];
+                var isSubmitted = booleanParameters[3];
+
+                var block = Adapt.blocks.findWhere({_trackingId: trackingId});
+                var component = block.getChildren().models[blockLocation];
+
+                component.set("_isComplete", true);
+                component.set("_isInteractionComplete", isInteractionComplete);
+                component.set("_isSubmitted", isSubmitted);
+                
+                if (hasUserAnswer) {
+                    var userAnswer = dataItem[2];
+                    if (!isUserAnswerArray) userAnswer = userAnswer[0];
+
+                    component.set("_userAnswer", userAnswer);
+                }
+
+
+            }
+        }
+    };
+
+    return serializer;
+});

--- a/js/serializers/questions.js
+++ b/js/serializers/questions.js
@@ -27,7 +27,6 @@ define([
             var rtn = "";
             try {
                 var data = this.captureData();
-                console.log(data);
                 rtn = SCORMSuspendData.serialize(data);
             } catch(e) {
                 console.error(e);
@@ -123,7 +122,6 @@ define([
 
             try {
                 var data = SCORMSuspendData.deserialize(str);
-                console.log(data);
                 this.releaseData( data );
             } catch(e) {
                 console.error(e);
@@ -153,7 +151,7 @@ define([
                 component.set("_isComplete", true);
                 component.set("_isInteractionComplete", isInteractionComplete);
                 component.set("_isSubmitted", isSubmitted);
-                
+
                 if (hasUserAnswer) {
                     var userAnswer = dataItem[2];
                     if (!isUserAnswerArray) userAnswer = userAnswer[0];

--- a/js/serializers/questions.js
+++ b/js/serializers/questions.js
@@ -25,12 +25,12 @@ define([
             }
 
             var rtn = "";
-            try {
+            //try {
                 var data = this.captureData();
                 rtn = SCORMSuspendData.serialize(data);
-            } catch(e) {
+            /*} catch(e) {
                 console.error(e);
-            }
+            }*/
 
             return rtn;
         },

--- a/js/serializers/questions.js
+++ b/js/serializers/questions.js
@@ -25,12 +25,12 @@ define([
             }
 
             var rtn = "";
-            //try {
+            try {
                 var data = this.captureData();
                 rtn = SCORMSuspendData.serialize(data);
-            /*} catch(e) {
+            } catch(e) {
                 console.error(e);
-            }*/
+            }
 
             return rtn;
         },

--- a/js/serializers/scormSuspendDataSerializer.js
+++ b/js/serializers/scormSuspendDataSerializer.js
@@ -1,0 +1,750 @@
+//https://raw.githubusercontent.com/oliverfoster/SCORMSuspendDataSerializer 2015-06-26
+(function() {
+
+	function indexOf(arr, func) {
+		for (var i = 0, l = arr.length; i < l; i++) {
+			var item = arr[i];
+			if (func( item, i )) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	function contains(arr, func) {
+		if (indexOf(arr, func) >= 0) return true;
+		return false;
+	}
+
+	function pluck(arr, func) {
+		var plucked = [];
+		for (var i = 0, l = arr.length; i < l; i++) {
+			var item = arr[i];
+			var val = func( item, i );
+			if (val) plucked.push(val);
+		}
+		return plucked;
+	}
+
+	function unique(arr) {
+		var names = {};
+		var uniques = [];
+		for (var i = 0, l = arr.length; i < l; i++) {
+			var item = arr[i];
+			if (typeof item == "object") {
+				uniques.push(item);
+			} else {
+				names[item] = 0;
+			}
+		}
+		for (var k in names) {
+			uniques.push(k);
+		}
+		return uniques;
+	}
+
+	function max(arr, func) {
+		var highestScore = 0;
+		var atIndex = -1;
+		for (var i = 0, l = arr.length; i < l; i++) {
+			var item = arr[i];
+			var score = func(item, i);
+			if ( score === true ) return arr[i];
+			if ( score >= highestScore ) {
+				highestScore = score;
+				atIndex = i;
+			}
+		}
+		return arr[atIndex];
+	}
+
+	function toPrecision(number, precision) {
+		if (precision === undefined) precision = 2
+		var multiplier = 1 * Math.pow(10, precision);
+		return Math.round(number * multiplier) / multiplier;
+	}
+
+	function BinaryToNumber(bin, length) {
+		return parseInt(bin.substr(0, length), 2);
+	}
+
+	function NumberToBinary(number, length) {
+		return Padding.fillLeft( number.toString(2), length );
+	}
+
+	var Padding = {
+		addLeft: function PaddingAddLeft(str, x , char) {
+			char = char || "0";
+			return (new Array( x + 1)).join(char) + str;
+		},
+		addRight: function PaddingAddRight(str, x, char) {
+			char = char || "0";
+			return  str + (new Array( x + 1)).join(char);
+		},
+		fillLeft: function PaddingFillLeft(str, x, char) {
+			if (str.length < x) {
+	        	var paddingLength = x - str.length;
+	        	return Padding.addLeft(str, paddingLength, char)
+	        }
+	        return str;
+		},
+		fillRight: function PaddingFillLeft(str, x, char) {
+			if (str.length < x) {
+	        	var paddingLength = x - str.length;
+	        	return Padding.addRight(str, paddingLength, char)
+	        }
+	        return str;
+		},
+		fillBlockLeft: function PaddingFillBlockRight(str, x, char) {
+			if (str.length % x) {
+	        	var paddingLength = x - (str.length % x);
+	        	return Padding.addLeft(str, paddingLength, char)
+	        }
+	        return str;
+		},
+		fillBlockRight: function PaddingFillBlockRight(str, x, char) {
+			if (str.length % x) {
+	        	var paddingLength = x - (str.length % x);
+	        	return Padding.addRight(str, paddingLength, char)
+	        }
+	        return str;
+		}
+	};
+
+	function Base64() {
+		switch (arguments.length) {
+		case 1:
+			var firstArgumentType = typeof arguments[0];
+			switch (firstArgumentType) {
+			case "number":
+				return Base64._indexes[arguments[0]];
+			case "string":
+				return Base64._chars[arguments[0]];
+			default:
+				throw "Invalid arguments type";
+			}
+		case 2:
+			var char = arguments[0];
+			var index = arguments[1];
+			Base64._chars[char] = index;
+			Base64._indexes[index] = char;
+			return;
+		default:
+			throw "Invalid number of arguments";
+		}
+	}
+	Base64._chars = {};
+	Base64._indexes = {};
+	(function() {
+		var alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+		for (var i = 0, l = alphabet.length; i<l; i++) {
+			Base64(alphabet[i], i);
+		}
+	})();
+
+
+	function DataType() {
+		switch (arguments.length) {
+		case 1:
+			switch (typeof  arguments[0]) {
+			case "object":
+				var item = arguments[0]
+				if (DataType._types[item.type] === undefined) DataType._types[item.type] = [];
+				DataType._types[item.type].push(item);
+				item.index = DataType._indexes.length
+				DataType._indexes.push(item);
+				DataType[item.name] = item;
+				return;
+			case "string":
+				return DataType.getName(arguments[0]);
+			case "number":
+				return DataType.getIndex(arguments[0]);
+			default:
+				throw "Argument type not allowed";
+			}
+		default:
+			throw "Too many arguments";
+		}
+		
+	}
+	DataType.VARIABLELENGTHDESCRIPTORSIZE = 7;
+	DataType._types = {};
+	DataType._indexes = [];
+	DataType.getName = function DataTypeGetName(name) {
+		if (DataType[name])
+			return DataType[name];
+		throw "Type name not found '"+name+"'";
+	};
+	DataType.getIndex = function DataTypeGetIndex(index) {
+		if (DataType._indexes[index])
+			return DataType._indexes[index];
+		throw "Type index not found '"+index+"'";
+	};
+	DataType.getTypes = function DataTypeGetTypes(type) {
+		if (DataType._types[type])
+			return DataType._types[type];
+		throw "Type not found '"+type+"'";
+	};
+	DataType.checkBounds = function DataTypeCheckBounds(name, number) {
+		var typeDef = DataType(name);
+		if (number > typeDef.max) throw name + " value is larger than "+typeDef.max;
+		if (number < typeDef.min) throw name + " value is smaller than "+typeDef.min;
+	};
+	DataType.getNumberType = function DataTypeGetNumberType(number) {
+		var isDecimal = (number - Math.floor(number)) !== 0;
+		var numberDataTypes = DataType.getTypes("number");
+		for (var t = 0, type; type = numberDataTypes[t++];) {
+			if (number <= type.max && number >= type.min && isDecimal == type.decimal ) {
+				return type;
+			}
+		}
+	};
+	DataType.getVariableType = function DataTypeGetVariableType(variable) {
+		var variableNativeType = variable instanceof Array ? "array" : typeof variable;
+		var variableDataType;
+
+		switch(variableNativeType) {
+		case "number":
+			variableDataType = DataType.getNumberType(variable);
+			break;
+		case "string":
+			variableDataType = DataType.getName("string");
+			break;
+		default: 
+			var supportedItemDataTypes = DataType.getTypes(variableNativeType);
+			switch (supportedItemDataTypes.length) {
+			case 1:
+				variableDataType = supportedItemDataTypes[0];
+				break;
+			default:
+				throw "Type not found '"+variableNativeType+"'";
+			}
+		}
+	
+		if (!variableDataType) throw "Cannot assess type '"+variableNativeType+"'";
+
+		return variableDataType;
+	};
+	DataType.getArrayType = function getArrayType(arr) {
+		var foundItemTypes = [];
+
+		for (var i = 0, l = arr.length; i < l; i++) {
+			var item = arr[i];
+			var itemDataType = DataType.getVariableType(item);
+	
+			if (contains(foundItemTypes, function(typ, index) { if (typ.name == itemDataType.name) return true; })) continue;
+
+			foundItemTypes.push(itemDataType);
+		}
+
+		switch (foundItemTypes.length) {
+		case 0:
+			throw "Cannot determine array data types";
+		case 1:
+			//single value type
+		 	return foundItemTypes[0];
+		default: 
+			//many value types
+			var nativeTypeNames = pluck(foundItemTypes, function(type) {
+				return type.type;
+			});
+			var uniqueNativeTypeNames = unique(nativeTypeNames);
+			var hasManyNativeTypes = (uniqueNativeTypeNames.length > 1);
+
+			if (hasManyNativeTypes) return DataType("variable"); //multiple types in array
+
+			//single native type in array, multiple datatype lengths
+			switch (uniqueNativeTypeNames[0]) {
+			case "number":
+				return max(foundItemTypes, function(type) {
+					if (type.decimal) return true;
+					return type.max;
+				});
+				
+			}
+
+			throw "Unsupported data types";
+		}
+		
+	};
+	(function() {
+		var types = [
+			{
+				"size": "fixed",
+				"length": 1,
+				"name": "boolean",
+				"type": "boolean"
+			},
+			{
+				"max": 15,
+				"min": 0,
+				"decimal": false,
+				"size": "fixed",
+				"length": 4,
+				"name": "half",
+				"type": "number"
+			},
+			{
+				"max": 255,
+				"min": 0,
+				"decimal": false,
+				"size": "fixed",
+				"length": 8,
+				"name": "byte",
+				"type": "number"
+			},
+			{
+				"max": 65535,
+				"min": 0,
+				"decimal": false,
+				"size": "fixed",
+				"length": 16,
+				"name": "short",
+				"type": "number"
+			},
+			{
+				"max": 4294967295,
+				"min": 0,
+				"decimal": false,
+				"size": "fixed",
+				"length": 32,
+				"name": "long",
+				"type": "number"
+			},
+			{
+				"max": 4294967295,
+				"min": -4294967295,
+				"decimal": true,
+				"precision": 2,
+				"size": "variable",
+				"name": "double",
+				"type": "number"
+			},
+			{
+				"name": "base16",
+				"size": "variable",
+				"type": "string"
+			},
+			{
+				"name": "base64",
+				"size": "variable",
+				"type": "string"
+			},
+			{
+				"name": "array",
+				"size": "variable",
+				"type": "array"
+			},
+			{
+				"name": "variable",
+				"size": "variable",
+				"type": "variable"
+			},
+			{
+				"name": "string",
+				"size": "variable",
+				"type": "string"
+			}
+		];
+		for (var i = 0, type; type = types[i++];) {
+			DataType(type);
+		}
+	})();
+
+	
+
+	function Converter(fromType, toType) {
+		fromType = Converter.translateTypeAlias(fromType);
+		toType = Converter.translateTypeAlias(toType);
+
+		var args = [].splice.call(arguments, 2);
+
+		if (fromType != "binary" && toType != "binary") {
+			if (!Converter._converters[fromType]) throw "Type not found '" + fromType + "'";
+			if (!Converter._converters[fromType]['binary']) throw "Type not found 'binary'";
+			
+			var bin = Converter._converters[fromType]['binary'].call(this, args[0], Converter.WRAPOUTPUT);
+
+			if (!Converter._converters['binary'][toType]) throw "Type not found '"+toType+"'";
+
+			return Converter._converters['binary'][toType].call(this, bin, Converter.WRAPOUTPUT);
+		}
+
+		if (!Converter._converters[fromType]) throw "Type not found '" + fromType + "'";
+		if (!Converter._converters[fromType][toType]) throw "Type not found '" + toType + "'";
+
+		return Converter._converters[fromType][toType].call(this, args[0], Converter.WRAPOUTPUT);
+	}
+	Converter.WRAPOUTPUT = false;
+	Converter.translateTypeAlias = function ConverterTranslateTypeAlias(type) {
+		type = type.toLowerCase();
+		for (var Type in Converter._typeAliases) {
+			if (Type == type || (" "+Converter._typeAliases[Type].join(" ")+" ").indexOf(" "+type+" ") >= 0 ) return Type;
+		}
+		throw "Type not found '" + type + "'";
+	};
+	Converter._typeAliases = {
+		"base64": [ "b64" ],
+		"base16" : [ "hex", "b16" ],
+		"double": [ "dbl", "decimal", "d" ],
+		"long": [ "lng", "l" ],
+		"short": [ "s" ],
+		"byte" : [ "b" ],
+		"half": [ "h" ],
+		"number": [ "num", "n" ],
+		"binary": [ "bin" ],
+		"boolean": [ "bool" ],
+		"array": [ "arr" ]
+	};
+	Converter._variableWrapLength = function ConverterVariableWrapLength(bin) {
+		var variableLength = bin.length;
+		var binLength = NumberToBinary(variableLength, DataType.VARIABLELENGTHDESCRIPTORSIZE)
+
+		return binLength + bin;
+	};
+	Converter._variableLength = function ConverterVariableLength(bin) {
+		var VLDS =  DataType.VARIABLELENGTHDESCRIPTORSIZE;
+		var variableLength = BinaryToNumber(bin, VLDS );
+		return variableLength;
+	};
+	Converter._variableUnwrapLength = function ConverterVariableUnwrapLength(bin) {
+		var VLDS =  DataType.VARIABLELENGTHDESCRIPTORSIZE;
+		var variableLength = BinaryToNumber(bin, VLDS );
+
+		return bin.substr( VLDS, variableLength);
+	};
+	Converter._converters = {
+		"base64": {
+			"binary": function ConverterBase64ToBinary(base64) { //TODO PADDING... ?
+				var firstByte = Base64(base64.substr(0,1));
+				var binFirstByte = NumberToBinary(firstByte, 6);
+				var paddingLength = BinaryToNumber(binFirstByte, 6);
+
+			    var bin = "";
+			    for (var i = 0, ch; ch = base64[i++];) {
+			        var block = Base64(ch).toString(2);
+			        block = Padding.fillLeft(block, 6);
+			        bin += block;
+			    }
+			    bin =  bin.substr(6+paddingLength);
+			    return bin;
+			}
+		},
+		"base16": {
+			"binary": function ConverterBase16ToBinary(hex) {
+				var firstByte = Base64(base64.substr(0,1));
+				var binFirstByte = NumberToBinary(firstByte, 4);
+				var paddingLength = BinaryToNumber(binFirstByte, 4);
+
+			    var bin = "";
+			    for (var i = 0, ch; ch = hex[i++];) {
+			        var block = parseInt(ch, 16).toString(2);
+			        block = Padding.fillLeft(block, 4);
+			        bin += block;
+			    }
+
+			     bin =  bin.substr(6+paddingLength);
+			    return bin;
+			}
+		},
+		"double": {
+			"binary": function ConverterDoubleToBinary(dbl, wrap) {
+				var typeDef = DataType("double");
+				DataType.checkBounds("double", dbl);
+
+				dbl = toPrecision(dbl, typeDef.precision);
+
+				var dblStr = dbl.toString(10);
+
+				var isMinus = dbl < 0;
+			
+				var baseStr, exponentStr, highStr, lowStr, decimalPosition, hasDecimal;
+
+				
+				var exponentPos = dblStr.indexOf("e");
+				if (exponentPos > -1) {
+					//exponential float representation "nE-x"
+					baseStr = dblStr.substr(0, exponentPos);
+					exponentStr = Math.abs(dblStr.substr(exponentPos+1));
+
+					if (isMinus) baseStr = baseStr.substr(1);
+
+					decimalPosition = baseStr.indexOf(".");
+					hasDecimal = (decimalPosition > -1);
+
+					if (hasDecimal) {
+						highStr = baseStr.substr(0, decimalPosition);
+						lowStr = baseStr.substr(decimalPosition+1);
+
+						exponentStr = (Math.abs(exponentStr) + lowStr.length);
+
+						baseStr = highStr + lowStr;
+					}
+
+				} else {
+					//normal long float representation "0.00000000"
+					baseStr = dblStr;
+					exponentStr = "0";
+
+					if (isMinus) dblStr = dblStr.substr(1);
+
+					decimalPosition = dblStr.indexOf(".");
+					hasDecimal = (decimalPosition > -1);
+					if (hasDecimal) {
+						highStr = dblStr.substr(0, decimalPosition);
+						lowStr = dblStr.substr(decimalPosition+1);
+
+						exponentStr = (lowStr.length);
+						if (highStr == "0") {
+							baseStr = parseInt(lowStr, 10).toString(10);
+						} else {
+							baseStr = highStr + lowStr;
+						}
+					}
+
+				}
+
+				var bin = [];
+
+				var binLong = Padding.fillBlockLeft (parseInt(baseStr, 10).toString(2), 4);
+				var binMinus = isMinus ? "1" : "0";
+				var binExponent = Padding.fillLeft( parseInt(exponentStr, 10).toString(2), 7);
+				
+				bin.push( binMinus );
+				bin.push( binExponent );
+				bin.push( binLong );
+
+				if (wrap === false) {
+					return bin.join("");
+				} else {
+					return Converter._variableWrapLength(bin.join(""));
+				}
+			}
+		},
+		"long": {
+			"binary": function ConverterLongToBinary(value) {
+				var typeDef = DataType("long");
+				DataType.checkBounds("long", value);
+				value = toPrecision(value, 0);
+				return Padding.fillLeft(value.toString(2), typeDef.length);
+			}
+		},
+		"short": {
+			"binary": function ConverterShortToBinary(value) {
+				var typeDef = DataType("short");
+				DataType.checkBounds("short", value);
+				value = toPrecision(value, 0);
+				return Padding.fillLeft(value.toString(2), typeDef.length);
+			}
+		},
+		"byte": {
+			"binary": function ConverterByteToBinary(value) {
+				var typeDef = DataType("byte");
+				DataType.checkBounds("byte", value);
+				value = toPrecision(value, 0);
+				return Padding.fillLeft(value.toString(2), typeDef.length);
+			}
+		},
+		"half": {
+			"binary": function ConverterHalfToBinary(value) {
+				var typeDef = DataType("half");
+				DataType.checkBounds("half", value);
+				value = toPrecision(value, 0);
+				return Padding.fillLeft(value.toString(2), typeDef.length);
+			}
+		},
+		"boolean": {
+			"binary": function ConverterBooleanToBinary(bool) {
+				return bool ? "1" : "0";
+			},
+		},
+		"array": {
+			"binary": function ConverterArrayToBinary(arr, wrap) { //TODO PADDING NOT GOOD
+				var typeDef = DataType("array");
+				var arrayItemType = DataType.getArrayType(arr);
+				var isVariableArray = arrayItemType.name == "vairable";
+
+				if (isVariableArray) {
+					var bin = half2bin(15);
+					//variable array
+					return bin;
+				} else {
+					var binArrayIdentifier = Converter._converters['half']['binary'](arrayItemType.index);
+
+					var binItemsArray = [];
+					for (var i = 0, l = arr.length; i < l; i++) {
+						var item = arr[i];
+						var binItem = Converter._converters[arrayItemType.name]['binary'](item);
+						//console.log("binItem", binItem);
+						binItemsArray.push( binItem );
+					}
+
+					var binItems = binItemsArray.join("");
+
+					var paddingLength = 0;
+					if (binItems.length % 4) paddingLength = 4 - (binItems.length % 4);
+					var binPaddingLen = NumberToBinary(paddingLength, 2);
+
+					var binPadding = (new Array(paddingLength+1)).join("0");
+
+					var bin = [];
+					bin.push(binArrayIdentifier);
+					bin.push(binPaddingLen);
+					bin.push(binPadding);
+					bin.push(binItems);
+
+					var finished = bin.join("");
+					//console.log("unwrapped", finished);
+
+					if (wrap === false) return finished;
+
+					var wrapped = Converter._variableWrapLength( finished);
+					//console.log("wrapped", wrapped);
+
+					return wrapped;
+				}
+
+			}
+		},
+		"binary": {
+			"array": function ConverterBinaryToArray(bin, wrap) { //TODO PADDING NOT GOOD
+				var typeDef = DataType("array");
+
+				//console.log("wrapped", bin);
+				if (wrap !== false)
+					bin = Converter._variableUnwrapLength( bin);
+				//console.log("unwrapped", bin);
+
+				var binArrayIdentifier = bin.substr(0, 4);
+				var binPaddingLen = bin.substr(4 , 2);
+
+				var arrayIdentifier = Converter._converters['binary'][ 'half' ]( binArrayIdentifier );
+				var paddingLength = BinaryToNumber( binPaddingLen, 2 );
+
+				var dataStart = 4 + 2 + paddingLength;
+				var dataLength = bin.length - dataStart;
+
+				var binItems = bin.substr(dataStart, dataLength );
+
+				var arrayItemType = DataType(arrayIdentifier);
+				var isVariableArray = arrayItemType.name == "variable";
+
+				var rtn = [];
+				if (isVariableArray) {
+
+				} else {
+					var hasVariableLengthChildren = arrayItemType.size == "variable";
+					if (hasVariableLengthChildren) {
+						var VLDS = DataType.VARIABLELENGTHDESCRIPTORSIZE;
+						while ( binItems != "" ) {
+							
+							var variableLength = Converter._variableLength( binItems );
+							var binItem = binItems.substr(0, VLDS + variableLength);
+							binItems = binItems.substr(VLDS+variableLength);
+							//console.log("binItem", binItem, BinaryToNumber(binItem, 16));
+
+							rtn.push( Converter._converters['binary'][ arrayItemType.name ]( binItem) );
+						}
+					} else {
+						while ( binItems != "" ) {
+							var binItem = binItems.substr(0, arrayItemType.length);
+							binItems = binItems.substr(arrayItemType.length);
+
+							rtn.push( Converter._converters['binary'][ arrayItemType.name ](binItem) );
+						}
+					}
+
+				}
+
+
+				return rtn;
+
+			},
+			"base64": function ConverterBinaryToBase64(bin) { //TODO PADDING NOT GOOD
+				var paddingLength = 0;
+				if (bin.length % 6) paddingLength = 6 - (bin.length % 6);
+				binPaddingLen = NumberToBinary(paddingLength, 6);
+				binPadding = Padding.addLeft("", paddingLength);
+				bin = binPaddingLen + binPadding + bin;
+
+				var binLength = bin.length;
+			    var base64 = "";
+			    for (var b = 0; b < 10000; b++) {
+			        if (b*6 >= binLength) break;
+			     
+			        var block = bin.substr(b*6,6);
+			        base64 += Base64(parseInt(block, 2));
+			    }
+
+			    return base64;
+			},
+			"base16": function ConverterBinaryToBase16(bin) {
+				var paddingLength = 0;
+				if (bin.length % 4) paddingLength = 4 - (bin.length % 4);
+				binPaddingLen = NumberToBinary(paddingLength, 4);
+				binPadding = Padding.addLeft("", paddingLength);
+				bin = binPaddingLen + binPadding + bin;
+
+			    var binLength = bin.length;
+			    var hex = "";
+			    for (var b = 0; b < 10000; b++) {
+			        if (b*4 >= binLength) break;
+			     
+			        var block = bin.substr(b*4,4);
+			        hex += parseInt(block, 2).toString(16);
+			    }
+			    return hex;
+			},
+			"double": function ConverterBinaryToDouble(bin, wrap) {
+				var typeDef = DataType("double");
+				
+				if (wrap !== false)
+					bin = Converter._variableUnwrapLength(bin);
+
+				var isMinus = bin.substr(0 ,1) == 1;
+
+				var exponentByte = parseInt("0" + bin.substr(1, 7), 2);
+				var baseLong = parseInt( bin.substr(8, bin.length), 2);
+
+				var dbl = parseFloat(baseLong+"E-"+exponentByte, 10);
+				if (isMinus) dbl = dbl * -1;
+
+				return dbl;
+			},
+			"long": function ConverterBinaryToLong(bin) {
+				return parseInt(bin.substr(0, 32), 2);
+			},
+			"short": function ConverterBinaryToShort(bin) {
+				return parseInt(bin.substr(0, 16), 2);
+			},
+			"byte": function ConverterBinaryToByte(bin) {
+				return parseInt(bin.substr(0, 8), 2);
+			},
+			"half": function ConverterBinaryToHalf(bin) {
+				return parseInt(bin.substr(0, 4), 2);
+			},
+			"boolean": function ConverterBinaryToBoolean(bin) {
+				return bin.substr(0,1) == "1" ? true: false;
+			},
+			"number": function ConverterBinaryToNumber(bin) {
+				return parseInt(bin, 2);
+			}
+		}
+	};
+	
+	window.SCORMSuspendData = {
+		serialize: function SCORMSuspendDataSerialize(arr) {
+			return Converter ("array", "base64", arr);
+		},
+		deserialize: function SCORMSuspendDataDeserialize(base64) {
+			return Converter("base64", "array", base64);
+		},
+		Base64: Base64,
+		Converter: Converter,
+		DataType: DataType
+	};
+
+
+})();
+
+

--- a/js/serializers/scormSuspendDataSerializer.js
+++ b/js/serializers/scormSuspendDataSerializer.js
@@ -1,62 +1,5 @@
-//https://raw.githubusercontent.com/oliverfoster/SCORMSuspendDataSerializer 2015-06-26
-(function() {
-
-	function indexOf(arr, func) {
-		for (var i = 0, l = arr.length; i < l; i++) {
-			var item = arr[i];
-			if (func( item, i )) {
-				return i;
-			}
-		}
-		return -1;
-	}
-
-	function contains(arr, func) {
-		if (indexOf(arr, func) >= 0) return true;
-		return false;
-	}
-
-	function pluck(arr, func) {
-		var plucked = [];
-		for (var i = 0, l = arr.length; i < l; i++) {
-			var item = arr[i];
-			var val = func( item, i );
-			if (val) plucked.push(val);
-		}
-		return plucked;
-	}
-
-	function unique(arr) {
-		var names = {};
-		var uniques = [];
-		for (var i = 0, l = arr.length; i < l; i++) {
-			var item = arr[i];
-			if (typeof item == "object") {
-				uniques.push(item);
-			} else {
-				names[item] = 0;
-			}
-		}
-		for (var k in names) {
-			uniques.push(k);
-		}
-		return uniques;
-	}
-
-	function max(arr, func) {
-		var highestScore = 0;
-		var atIndex = -1;
-		for (var i = 0, l = arr.length; i < l; i++) {
-			var item = arr[i];
-			var score = func(item, i);
-			if ( score === true ) return arr[i];
-			if ( score >= highestScore ) {
-				highestScore = score;
-				atIndex = i;
-			}
-		}
-		return arr[atIndex];
-	}
+//https://raw.githubusercontent.com/oliverfoster/SCORMSuspendDataSerializer 2015-06-27
+(function(_) {
 
 	function toPrecision(number, precision) {
 		if (precision === undefined) precision = 2
@@ -231,9 +174,9 @@
 		for (var i = 0, l = arr.length; i < l; i++) {
 			var item = arr[i];
 			var itemDataType = DataType.getVariableType(item);
-	
-			if (contains(foundItemTypes, function(typ, index) { if (typ.name == itemDataType.name) return true; })) continue;
 
+			if (_.findWhere(foundItemTypes, { name: itemDataType.name })) continue;
+	
 			foundItemTypes.push(itemDataType);
 		}
 
@@ -245,10 +188,8 @@
 		 	return foundItemTypes[0];
 		default: 
 			//many value types
-			var nativeTypeNames = pluck(foundItemTypes, function(type) {
-				return type.type;
-			});
-			var uniqueNativeTypeNames = unique(nativeTypeNames);
+			var nativeTypeNames = _.pluck(foundItemTypes, 'type');
+			var uniqueNativeTypeNames = _.uniq(nativeTypeNames);
 			var hasManyNativeTypes = (uniqueNativeTypeNames.length > 1);
 
 			if (hasManyNativeTypes) return DataType("variable"); //multiple types in array
@@ -256,7 +197,7 @@
 			//single native type in array, multiple datatype lengths
 			switch (uniqueNativeTypeNames[0]) {
 			case "number":
-				return max(foundItemTypes, function(type) {
+				return _.max(foundItemTypes, function(type) {
 					if (type.decimal) return true;
 					return type.max;
 				});
@@ -747,6 +688,4 @@
 	};
 
 
-})();
-
-
+})(_);

--- a/js/serializers/scormSuspendDataSerializer.js
+++ b/js/serializers/scormSuspendDataSerializer.js
@@ -194,7 +194,7 @@
 		var isDecimal = (number - Math.floor(number)) !== 0;
 		var numberDataTypes = DataType.getTypes("number");
 		for (var t = 0, type; type = numberDataTypes[t++];) {
-			if (number <= type.max && number >= type.min && isDecimal == type.decimal ) {
+			if (number <= type.max && number >= type.min && (!isDecimal || isDecimal == type.decimal) ) {
 				return type;
 			}
 		}
@@ -500,6 +500,8 @@
 						} else {
 							baseStr = highStr + lowStr;
 						}
+					} else {
+						baseStr = dblStr;
 					}
 
 				}


### PR DESCRIPTION
Extended spoor scorm tracking to optionally include question component users selections.

For issue: https://adaptlearning.atlassian.net/browse/ABU-676
Forum: https://community.adaptlearning.org/mod/forum/discuss.php?d=784
From: https://github.com/cgkineo-projects/adapt-contrib-spoor/tree/ABU-676
Utilizes: https://github.com/oliverfoster/SCORMSuspendDataSerializer
Example: https://rawgit.com/oliverfoster/spoor-extended/master/scorm_test_harness.html

What it does:

Capture _isInteractionComplete, _isComplete, _isSubmitted and _userAnswer from the question components, save and restore them to the LMS.
It ignores questions with _isResetOnRevisit: true.
It is off by default but can be turned on in the config.json