### PR TITLE
Decimal array fix

### DIFF
--- a/js/serializers/scormSuspendDataSerializer.js
+++ b/js/serializers/scormSuspendDataSerializer.js
@@ -197,11 +197,11 @@
 			//single native type in array, multiple datatype lengths
 			switch (uniqueNativeTypeNames[0]) {
 			case "number":
+				var foundDecimal = _.findWhere(foundItemTypes, { decimal: true});
+				if (foundDecimal) return foundDecimal;
 				return _.max(foundItemTypes, function(type) {
-					if (type.decimal) return true;
 					return type.max;
 				});
-				
 			}
 
 			throw "Unsupported data types";


### PR DESCRIPTION
* Update to always choose to convert to a decimal array when the numeric array being saved contains a decimal value.

When a text input with 2 input boxes has answers of  1 correct and 1 incorrect it produces the array > [0,-1]

Arrays must have a common type in order to be saved in this format. Therefore a numeric array must be normalized before it is saved.

As decimal is the only numeric type (from half, byte, short, long and decimal) to accommodate negative numbers:

[0, -1] would be a decimal array
[half, decimal] > [decimal, decimal]

have forced this behaviour