### PR TITLE
Fix: initialize at config load not course load

### DIFF
--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -20,19 +20,22 @@ define([
 	//Session Begin
 
 		initialize: function() {
+			this.listenToOnce(Adapt, "configModel:dataLoaded", this.onConfigLoaded);
 			this.listenToOnce(Adapt, "app:dataReady", this.onDataReady);
 		},
 
-		onDataReady: function() {
+		onConfigLoaded: function() {
 			if (!this.checkConfig()) return;
 
 			this.configureAdvancedSettings();
 
 			scorm.initialize();
 
-			adaptStatefulSession.initialize();
-
 			this.setupEventListeners();
+		},
+
+		onDataReady: function() {
+			adaptStatefulSession.initialize();
 		},
 
 		checkConfig: function() {


### PR DESCRIPTION
* Allows for language to be saved / restored before the course data has loaded
* Allows for multiple language folders and pre-load language selection such as > https://github.com/cgkineo/adapt-languageSelection/blob/master/js/langsel.js