### PR TITLE
adapt-contrib-spoor.js: ensure that `setVersion` is called even when 

### DIFF
--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -65,6 +65,12 @@ define([
 				if(settings.hasOwnProperty("_commitRetryDelay")) {
 					scorm.commitRetryDelay = settings._commitRetryDelay;
 				}
+			} else {
+				/**
+        * force use of SCORM 1.2 by default - some LMSes (SABA/Kallidus for instance) present both APIs to the SCO and, if given the choice,
+        * the pipwerks code will automatically select the SCORM 2004 API - which can lead to unexpected behaviour.
+        */
+				scorm.setVersion("1.2");
 			}
 		},
 

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -77,7 +77,7 @@ define (function(require) {
 		 * (e.g. setting it to 'logout' apparently causes Plateau to log the user completely out of the LMS!)
 		 * It needs to be on for SCORM 2004 though, otherwise the LMS might not restore the suspend_data
 		 */
-		this.scorm.handleExitMode = (this.scorm.version === "2004");
+		this.scorm.handleExitMode = this.isSCORM2004();
 	};
 
 	ScormWrapper.prototype.initialize = function() {


### PR DESCRIPTION
`_advancedSettings` are not set (fixes ([https://adaptlearning.atlassian.net/browse/ABU-1076](ABU-1076))

wrapper.js: refactor `setVersion` so that it uses the pre-existing `isSCORM2004` function