### PR TITLE
The "silent" property

### DIFF
--- a/example.json
+++ b/example.json
@@ -2,6 +2,7 @@
 {
 	"_spoor": {
 		"_isEnabled": true,
+        	"_silent": true,
 		"_tracking": {
 			"_requireCourseCompleted": true,
 			"_requireAssessmentPassed": false,

--- a/example.json
+++ b/example.json
@@ -2,7 +2,6 @@
 {
 	"_spoor": {
 		"_isEnabled": true,
-        	"_silent": true,
 		"_tracking": {
 			"_requireCourseCompleted": true,
 			"_requireAssessmentPassed": false,
@@ -22,7 +21,8 @@
 			"_commitOnStatusChange": false,
 			"_timedCommitFrequency": 10,
 			"_maxCommitRetries": 5,
-			"_commitRetryDelay": 2000
+			"_commitRetryDelay": 2000,
+        		"_suppressErrors": true
 		}
 	}
 }

--- a/example.json
+++ b/example.json
@@ -22,7 +22,7 @@
 			"_timedCommitFrequency": 10,
 			"_maxCommitRetries": 5,
 			"_commitRetryDelay": 2000,
-        		"_suppressErrors": true
+        		"_suppressErrors": false
 		}
 	}
 }

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -21,10 +21,6 @@ define([
 		onConfigLoaded: function() {
 			if (!this.checkConfig()) return;
 
-			if(this._config.hasOwnProperty("_silent")) {
-				scorm.silent = this._config._silent;
-			}
-
 			this.configureAdvancedSettings();
 
 			scorm.initialize();
@@ -53,6 +49,10 @@ define([
 				if(settings._showDebugWindow) scorm.showDebugWindow();
 
 				scorm.setVersion(settings._scormVersion || "1.2");
+
+				if(settings.hasOwnProperty("_suppressErrors")) {
+					scorm.suppressErrors = settings._suppressErrors;
+				}
 
 				if(settings.hasOwnProperty("_commitOnStatusChange")) {
 					scorm.commitOnStatusChange = settings._commitOnStatusChange;

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -21,6 +21,10 @@ define([
 		onConfigLoaded: function() {
 			if (!this.checkConfig()) return;
 
+			if(this._config.hasOwnProperty("_silent")) {
+				scorm.silent = this._config._silent;
+			}
+
 			this.configureAdvancedSettings();
 
 			scorm.initialize();

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -49,7 +49,9 @@ define (function(require) {
 		this.logger = Logger.getInstance();
 		this.scorm = pipwerks.SCORM;
 
-		if (window.__debug)
+        	this.silent = false;
+        
+		if (window.__debug && !this.silent)
 			this.showDebugWindow();
 	};
 
@@ -491,7 +493,7 @@ define (function(require) {
 	ScormWrapper.prototype.handleError = function(_msg) {
 		this.logger.error(_msg);
 		
-		if ((!this.logOutputWin || this.logOutputWin.closed) && confirm("An error has occured:\n\n" + _msg + "\n\nPress 'OK' to view debug information to send to technical support."))
+		if (!this.silent && (!this.logOutputWin || this.logOutputWin.closed) && confirm("An error has occured:\n\n" + _msg + "\n\nPress 'OK' to view debug information to send to technical support."))
 			this.showDebugWindow();
 	};
 

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -49,9 +49,9 @@ define (function(require) {
 		this.logger = Logger.getInstance();
 		this.scorm = pipwerks.SCORM;
 
-        	this.silent = false;
+        	this.suppressErrors = false;
         
-		if (window.__debug && !this.silent)
+		if (window.__debug)
 			this.showDebugWindow();
 	};
 
@@ -493,7 +493,7 @@ define (function(require) {
 	ScormWrapper.prototype.handleError = function(_msg) {
 		this.logger.error(_msg);
 		
-		if (!this.silent && (!this.logOutputWin || this.logOutputWin.closed) && confirm("An error has occured:\n\n" + _msg + "\n\nPress 'OK' to view debug information to send to technical support."))
+		if (!this.suppressErrors && (!this.logOutputWin || this.logOutputWin.closed) && confirm("An error has occured:\n\n" + _msg + "\n\nPress 'OK' to view debug information to send to technical support."))
 			this.showDebugWindow();
 	};
 

--- a/properties.schema
+++ b/properties.schema
@@ -150,6 +150,15 @@
                       "inputType": "Number",
                       "validators": ["number"],
                       "help": "How much of a delay (in milliseconds) to leave between commit retries."
+                    },
+                    "_suppressErrors": {
+                      "type":"boolean",
+                      "required":false,
+                      "default": "false",
+                      "title":"Supress LMS errors",
+                      "inputType": {"type": "Boolean", "options": [true, false]},
+                      "validators": [],
+                      "help": "Whether spoor plugin should show any errors to the user."
                     }
                   }
                 }

--- a/properties.schema
+++ b/properties.schema
@@ -158,7 +158,7 @@
                       "title":"Supress LMS errors",
                       "inputType": {"type": "Boolean", "options": [true, false]},
                       "validators": [],
-                      "help": "Whether spoor plugin should show any errors to the user."
+                      "help": "Set this to 'true' to stop this plugin from displaying error messages when tracking problems occur."
                     }
                   }
                 }


### PR DESCRIPTION
Add silent property that will prevent (when true) appearance of any error popups along with debug window without disabling spoor. Useful when the same build must be used in LMS and non-LMS environment.