### PR TITLE
The "silent" property - master

### DIFF
--- a/example.json
+++ b/example.json
@@ -2,6 +2,7 @@
 {
 	"_spoor": {
 		"_isEnabled": true,
+        	"_silent": true,
 		"_tracking": {
 			"_requireCourseCompleted": true,
 			"_requireAssessmentPassed": false,

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -21,6 +21,10 @@ define([
 		onConfigLoaded: function() {
 			if (!this.checkConfig()) return;
 
+			if(this._config.hasOwnProperty("_silent")) {
+				scorm.silent = this._config._silent;
+			}
+
 			this.configureAdvancedSettings();
 
 			scorm.initialize();

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -56,7 +56,9 @@ define (function(require) {
 
 		this.registeredViews = [];
 		
-		if (window.__debug)
+		this.silent = false;
+		
+		if (window.__debug && !this.silent)
 			this.showDebugWindow();
 	};
 
@@ -502,7 +504,7 @@ define (function(require) {
 	ScormWrapper.prototype.handleError = function(_msg) {
 		this.logger.error(_msg);
 		
-		if ((!this.logOutputWin || this.logOutputWin.closed) && confirm("An error has occured:\n\n" + _msg + "\n\nPress 'OK' to view debug information to send to technical support."))
+		if (!this.silent && (!this.logOutputWin || this.logOutputWin.closed) && confirm("An error has occured:\n\n" + _msg + "\n\nPress 'OK' to view debug information to send to technical support."))
 			this.showDebugWindow();
 	};
 


### PR DESCRIPTION
Add silent property that will prevent (when true) appearance of any error popups along with debug window without disabling spoor. Useful when the same build must be used in LMS and non-LMS environment.