### PR TITLE
hotfix/at-saverestore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://adaptlearning.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10100&issuetype=1&priority=6&components=10520",

--- a/js/serializers/questions.js
+++ b/js/serializers/questions.js
@@ -53,7 +53,7 @@ define([
                     var blockId = component._parentId;
 
                     if (!blocks[blockId]) {
-                            blocks[blockId] = blockModel.toJSON();
+                        blocks[blockId] = blockModel.toJSON();
                     }
 
                     var block = blocks[blockId];
@@ -64,11 +64,6 @@ define([
 
                     if (component['_isInteractionComplete'] === false || component['_isComplete'] === false) {
                         //if component is not currently complete skip it
-                        continue;
-                    }
-
-                    if (block['_trackingId'] === undefined) {
-                        //if block has no tracking id, skip it
                         continue;
                     }
 

--- a/js/serializers/questions.js
+++ b/js/serializers/questions.js
@@ -37,76 +37,82 @@ define([
         captureData: function() {
             var data = [];
             
-            var components = Adapt.components.toJSON();
-
-            components = _.where(components, includes);
-
+            var trackingIds = Adapt.blocks.pluck("_trackingId");
             var blocks = {};
             var countInBlock = {};
 
-            for (var i = 0, l = components.length; i < l; i++) {
-                var component = components[i];
-                var blockId = component._parentId;
+            for (var i = 0, l = trackingIds.length; i < l; i++) {
 
-                if (!blocks[blockId]) {
-                    blocks[blockId] = Adapt.findById(blockId).toJSON();
-                }
+                var trackingId = trackingIds[i];
+                var blockModel = Adapt.blocks.findWhere({_trackingId: trackingId });
+                var componentModels = blockModel.getChildren().where(includes);
 
-                var block = blocks[blockId];
-                if (countInBlock[blockId] === undefined) countInBlock[blockId] = -1;
-                countInBlock[blockId]++;
+                for (var c = 0, cl = componentModels.length; c < cl; c++) {
 
-                var blockLocation = countInBlock[blockId];
+                    var component = componentModels[c].toJSON();
+                    var blockId = component._parentId;
 
-                if (component['_isInteractionComplete'] === false || component['_isComplete'] === false) {
-                    //if component is not currently complete skip it
-                    continue;
-                }
+                    if (!blocks[blockId]) {
+                            blocks[blockId] = blockModel.toJSON();
+                    }
 
-                if (block['_trackingId'] === undefined) {
-                    //if block has no tracking id, skip it
-                    continue;
-                }
+                    var block = blocks[blockId];
+                    if (countInBlock[blockId] === undefined) countInBlock[blockId] = -1;
+                    countInBlock[blockId]++;
 
-                var hasUserAnswer = (component['_userAnswer'] !== undefined);
-                var isUserAnswerArray = (component['_userAnswer'] instanceof Array);
+                    var blockLocation = countInBlock[blockId];
 
-
-                var numericParameters = [
-                        blockLocation,
-                        block['_trackingId'],
-                        component['_score'] || 0
-                    ];
-
-                var booleanParameters = [
-                        hasUserAnswer,
-                        isUserAnswerArray,
-                        component['_isInteractionComplete'],
-                        component['_isSubmitted'],
-                        component['_isCorrect'] || false
-                    ];
-
-                var dataItem = [
-                    numericParameters,
-                    booleanParameters
-                ];
-
-
-                if (hasUserAnswer) {
-                    var userAnswer = isUserAnswerArray ? component['_userAnswer'] : [component['_userAnswer']];
-
-                    var arrayType = SCORMSuspendData.DataType.getArrayType(userAnswer);
-
-                    switch(arrayType.name) {
-                    case "string": case "variable":
-                        console.log("Cannot store _userAnswers from component " + component._id + " as array is of variable or string type.");
+                    if (component['_isInteractionComplete'] === false || component['_isComplete'] === false) {
+                        //if component is not currently complete skip it
                         continue;
                     }
 
-                    dataItem.push(userAnswer);
-                }
+                    if (block['_trackingId'] === undefined) {
+                        //if block has no tracking id, skip it
+                        continue;
+                    }
 
-                data.push(dataItem);
+                    var hasUserAnswer = (component['_userAnswer'] !== undefined);
+                    var isUserAnswerArray = (component['_userAnswer'] instanceof Array);
+
+
+                    var numericParameters = [
+                            blockLocation,
+                            block['_trackingId'],
+                            component['_score'] || 0
+                        ];
+
+                    var booleanParameters = [
+                            hasUserAnswer,
+                            isUserAnswerArray,
+                            component['_isInteractionComplete'],
+                            component['_isSubmitted'],
+                            component['_isCorrect'] || false
+                        ];
+
+                    var dataItem = [
+                        numericParameters,
+                        booleanParameters
+                    ];
+
+
+                    if (hasUserAnswer) {
+                        var userAnswer = isUserAnswerArray ? component['_userAnswer'] : [component['_userAnswer']];
+
+                        var arrayType = SCORMSuspendData.DataType.getArrayType(userAnswer);
+
+                        switch(arrayType.name) {
+                        case "string": case "variable":
+                            console.log("Cannot store _userAnswers from component " + component._id + " as array is of variable or string type.");
+                            continue;
+                        }
+
+                        dataItem.push(userAnswer);
+                    }
+
+                    data.push(dataItem);
+
+                }
 
             }
 


### PR DESCRIPTION
- use the same method to locate components in blocks for both save and restore
- fixes issue whereby authoring tool doesn't output components in coherent order