### PR TITLE
issue-957: isoptional and component completion restore

### DIFF
--- a/js/serializers/default.js
+++ b/js/serializers/default.js
@@ -71,7 +71,7 @@ define([
         },
 
         markBlockAsComplete: function(block) {
-            if (!block || block.get('_isComplete')) {
+            if (!block) {
                 return;
             }
         


### PR DESCRIPTION
Allow spoor to restore component completion if block is already complete. isOptional fix.