### PR TITLE
Add visibilitychange listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 
 >>**_commitRetryDelay** (number): Specifies the interval in milliseconds between commit retries. The default is `2000`.
 
+>>**_commitOnVisibilityChangeHidden** (boolean): Determines whether a "commit" call should be made whenever the course becomes hidden. The default is `true`.
+
 <div float align=right><a href="#top">Back to Top</a></div>  
 
 ###Running a course without tracking while Spoor is installed  

--- a/example.json
+++ b/example.json
@@ -22,7 +22,8 @@
 			"_commitOnStatusChange": true,
 			"_timedCommitFrequency": 10,
 			"_maxCommitRetries": 5,
-			"_commitRetryDelay": 2000
+			"_commitRetryDelay": 2000,
+			"_commitOnVisibilityChangeHidden": true
 		}
 	}
 }

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -84,10 +84,15 @@ define([
     },
 
     setupEventListeners: function() {
+      var advancedSettings = this._config._advancedSettings;
+      var shouldCommitOnVisibilityChange = (!advancedSettings ||
+        advancedSettings._commitOnVisibilityChangeHidden !== false) &&
+        document.addEventListener;
+
       this._onWindowUnload = _.bind(this.onWindowUnload, this);
       $(window).on('unload', this._onWindowUnload);
 
-      if (document.addEventListener) {
+      if (shouldCommitOnVisibilityChange) {
         document.addEventListener("visibilitychange", this.onVisibilityChange);
       }
     },

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -86,6 +86,14 @@ define([
     setupEventListeners: function() {
       this._onWindowUnload = _.bind(this.onWindowUnload, this);
       $(window).on('unload', this._onWindowUnload);
+
+      if (document.addEventListener) {
+        document.addEventListener("visibilitychange", this.onVisibilityChange);
+      }
+    },
+
+    onVisibilityChange: function() {
+      if (document.visibilityState === "hidden") scorm.commit();
     },
 
   //Session End

--- a/properties.schema
+++ b/properties.schema
@@ -159,6 +159,14 @@
                       "inputType": {"type": "Boolean", "options": [true, false]},
                       "validators": [],
                       "help": "Set this to 'true' to stop this plugin from displaying error messages when tracking problems occur."
+                    },
+                    "_commitOnVisibilityChangeHidden": {
+                      "type": "boolean",
+                      "default": true,
+                      "title": "Commit on visibility change hidden",
+                      "inputType": { "type": "Boolean", "options": [ true, false ] },
+                      "validators": [],
+                      "help": "Whether a 'commit' call should be made whenever the course becomes hidden."
                     }
                   }
                 }


### PR DESCRIPTION
Uses the Page Visibility API to perform a SCORM commit whenever a course becomes hidden.

In my tests on Moodle, the `visibilitychange` event was firing successfully in the following:
* iOS 8
* iOS 9
* Android 6
* Safari 9
* Firefox 47

The event wasn't so consistent in:
* Chrome 51
* Edge 25
* IE 11

Although the original link mentions also implementing a `pagehide` listener, the `unload` handler was firing successfully in the cases where `pagehide` worked.

Original issue: https://github.com/adaptlearning/adapt_framework/issues/873.