### PR TITLE
force suspendDataStore to initialise prior...

### DIFF
--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -28,6 +28,12 @@ define([
 
       scorm.initialize();
 
+      /*
+      force offlineStorage-scorm to initialise suspendDataStore - if we don't then we won't be able to do things like store the user's chosen language
+      as this has to be done before the rest of the course data loads (i.e. before suspendDataStore gets accessed properly for the purpose of restoring tracking data) 
+      */ 
+      Adapt.offlineStorage.get();
+
       Adapt.offlineStorage.setReadyStatus();
 
       this.setupEventListeners();

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -29,8 +29,8 @@ define([
       scorm.initialize();
 
       /*
-      force offlineStorage-scorm to initialise suspendDataStore - if we don't then we won't be able to do things like store the user's chosen language
-      as this has to be done before the rest of the course data loads (i.e. before suspendDataStore gets accessed properly for the purpose of restoring tracking data) 
+      force offlineStorage-scorm to initialise suspendDataStore - this allows us to do things like store the user's 
+      chosen language before the rest of the course data loads 
       */ 
       Adapt.offlineStorage.get();
 

--- a/js/adapt-offlineStorage-scorm.js
+++ b/js/adapt-offlineStorage-scorm.js
@@ -95,9 +95,7 @@ define([
 					}
 
 					var dataAsString = JSON.stringify(suspendDataStore);
-					// make sure the user's selected language is written into suspend_data even if the suspend_data hasn't been retrieved yet
-					// if the language picker is being used on first launch this needs to be done before the suspend_data is restored
-					return (suspendDataRestored || name.toLowerCase() === "lang") ? scorm.setSuspendData(dataAsString) : false;
+					return (suspendDataRestored) ? scorm.setSuspendData(dataAsString) : false;
 			}
 		},
 


### PR DESCRIPTION
... to any attempt to store the user's chosen language - should fix https://github.com/adaptlearning/adapt-contrib-languagePicker/issues/18

remove workaround from adapt-offlineStorage-scorm.js as this should no longer be necessary