### PR TITLE
Added warning to debug log if using offline API.

### DIFF
--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -53,6 +53,9 @@ define (function(require) {
         
 		if (window.__debug)
 			this.showDebugWindow();
+
+		if ((window.API && window.API.__offlineAPIWrapper) || (window.API_1484_11 && window.API_1484_11.__offlineAPIWrapper))
+			this.logger.error("Offline SCORM API is being used. No data will be reported to the LMS!");
 	};
 
 	// static

--- a/required/offline_API_wrapper.js
+++ b/required/offline_API_wrapper.js
@@ -12,6 +12,9 @@ function createResetButton(API) {
 
 
 var API = {
+	
+	__offlineAPIWrapper:true,
+
 	LMSInitialize: function() {
 		//if (window.ISCOOKIELMS !== false) createResetButton(this);
 		if (!API.LMSFetch()) {
@@ -86,6 +89,9 @@ var API = {
 };
 
 var API_1484_11 = {
+
+	__offlineAPIWrapper:true,
+
 	Initialize: function() {
 		//if (window.ISCOOKIELMS !== false) createResetButton(this);
 		if (!API_1484_11.LMSFetch()) {


### PR DESCRIPTION
Will help quickly determine if user has linked to incorrect launch file when deploying to LMS. This happened recently - a client used an uploader tool which clearly did not abide the settings in the imsmanifest.xml. index.html was selected as the launch file rather than index_lms.html and therefore no data was reported to the LMS.

**Expected usage**: tracking problems reported on LMS. Enable debugging in config, redeploy and first line of debug log will reveal if the appropriate tracking API is being used.