### PR TITLE
Added support for IE 8 shim as defined in framework issue #1335

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "2.0.14",
-  "framework": "^2.0.13",
+  "version": "2.0.15",
+  "framework": "^2.0.16",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-spoor%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20the%20contents%20of%20the%20SCORM%20debug%20window.",
   "displayName" : "Spoor",

--- a/required/index.html
+++ b/required/index.html
@@ -15,6 +15,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
         <link href="adapt/css/adapt.css" type="text/css" rel="stylesheet">
         <script src="libraries/modernizr.js" type="text/javascript"></script>
+        <!--[if lt IE 9]>
+        <script src="libraries/es5-shim.min.js" type="text/javascript"></script>
+        <![endif]-->
         <script src="adapt/js/scriptLoader.js" type="text/javascript"></script>
     </head>
 


### PR DESCRIPTION
This is dependent upon https://github.com/adaptlearning/adapt_framework/pull/1346.

Don't merge this until that goes in and the framework has been bumped.