### PR TITLE
Wrapped SCORM finish in finishCalled check

### DIFF
--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -126,7 +126,9 @@ define([
         onWindowUnload: function() {
             $(window).off('beforeunload unload', this._onWindowUnload);
 
-            scorm.finish();
+            if (!scorm.finishCalled){
+                scorm.finish();
+            }
         }
         
     }, Backbone.Events);


### PR DESCRIPTION
Another component/extension in a course may have already called finish against SCORM (close button for example).

This prevent an 'LMS is not longer connected' message box.