### PR TITLE
amend getISO8601Timestamp to use date.toISOString

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-spoor",
   "version": "2.0.15",
-  "framework": "^2.0.15",
+  "framework": "^2.0.16",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-spoor%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20the%20contents%20of%20the%20SCORM%20debug%20window.",
   "displayName" : "Spoor",

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -632,23 +632,12 @@ define (function(require) {
 		return [hours, min, sec].join(":");
 	};
 
-	ScormWrapper.prototype.getISO8601Timestamp = function() {
-	
-		var date = new Date();
-		
-		var ymd = [
-			date.getFullYear(),
-			this.padWithZeroes(date.getMonth()+1,2),
-			this.padWithZeroes(date.getDate(),2)
-		].join("-");
-
-		var hms = [
-			this.padWithZeroes(date.getHours(),2),
-			this.padWithZeroes(date.getMinutes(),2),
-			this.padWithZeroes(date.getSeconds(),2)
-		].join(":");
-
-		return ymd + "T" + hms;
+	/**
+	* returns the current date & time in the format YYYY-MM-DDTHH:mm:ss 
+	*/
+	ScormWrapper.prototype.getISO8601Timestamp = function() {		
+		var date = new Date().toISOString();
+		return date.replace(/.\d\d\dZ/, "");//Date.toISOString returns the date in the format YYYY-MM-DDTHH:mm:ss.sssZ so we need to drop the last bit to make it SCORM 2004 conformant
 	};
 
 	ScormWrapper.prototype.padWithZeroes = function(numToPad, padBy) {


### PR DESCRIPTION
as per https://github.com/adaptlearning/adapt_framework/issues/1363

if you want to test you'll need to publish a course as SCORM 2004 with `_tracking._shouldRecordInteractions` set to `true` in your `_spoor` config - or you could just have a look at the version I [uploaded to SCORM Cloud](https://cloud.scorm.com/sc/InvitationConfirmEmail?publicInvitationId=308a4475-22cb-4b52-8c72-03e5d6a42272) ;-)

To test, answer a few questions and check you don't get any errors about cmi.interactions.n.timestamp being in the wrong format

