### PR TITLE
ensure commas are url-encoded

### DIFF
--- a/required/offline_API_wrapper.js
+++ b/required/offline_API_wrapper.js
@@ -219,6 +219,18 @@ var API_1484_11 = {
 
 		var pluses = /\+/g;
 
+		/**
+		 * Safari-for-iOS 10 doesn't like values in JSON strings to contain commas, and will simply
+		 * truncate the data at the point it finds one - see https://github.com/adaptlearning/adapt_framework/issues/1589
+		 * We can't just URL-encode the entire thing as that pretty much doubles the size of the data, see:
+		 * https://github.com/adaptlearning/adapt_framework/issues/1535
+		 * According to https://developer.mozilla.org/en-US/docs/Web/API/document/cookie, semi-colons and whitespace
+		 * are also disallowed, but so far we don't seem to be having problems because of them
+		 */
+		function urlEncodeDisallowedChars(value) {
+			var s = (config.json ? JSON.stringify(value) : String(value));
+			return s.replace(/,/g, '%2C');
+		}
 
 		function parseCookieValue(s) {
 			if (s.indexOf('"') === 0) {
@@ -253,7 +265,7 @@ var API_1484_11 = {
 				}
 
 				return (document.cookie = [
-					key, '=', value,
+					key, '=', urlEncodeDisallowedChars(value),
 					options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
 					options.path    ? '; path=' + options.path : '',
 					options.domain  ? '; domain=' + options.domain : '',

--- a/required/offline_API_wrapper.js
+++ b/required/offline_API_wrapper.js
@@ -63,7 +63,7 @@ var API = {
 		return "Fake error string.";
 	},
 	LMSGetDiagnostic: function() {
-		return "Fake diagnostic information."
+		return "Fake diagnostic information.";
 	},
 	LMSStore: function(force) {
 		if (window.ISCOOKIELMS === false) return;
@@ -77,7 +77,7 @@ var API = {
 		}
 		this.data = API.cookie("_spoor");
 		if (this.data === undefined) {
-			this.data = {}
+			this.data = {};
 			return false;
 		} else {
 			this.data = JSON.parse(this.data);
@@ -141,7 +141,7 @@ var API_1484_11 = {
 		return "Fake error string.";
 	},
 	GetDiagnostic: function() {
-		return "Fake diagnostic information."
+		return "Fake diagnostic information.";
 	},
 	LMSStore: function(force) {
 		if (window.ISCOOKIELMS === false) return;
@@ -155,7 +155,7 @@ var API_1484_11 = {
 		}
 		this.data = API_1484_11.cookie("_spoor");
 		if (this.data === undefined) {
-			this.data = {}
+			this.data = {};
 			return false;
 		} else {
 			this.data = JSON.parse(this.data);


### PR DESCRIPTION
before being written to the cookie, so as to avoid a bug in Safari for iOS v10 (https://github.com/adaptlearning/adapt_framework/issues/1589)