### PR TITLE
amend to ensure that the visibilitychange event listener is removed

### DIFF
--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -120,6 +120,12 @@ define([
             });
         },
 
+        removeEventListeners: function() {
+            $(window).off('beforeunload unload', this._onWindowUnload);
+
+            document.removeEventListener("visibilitychange", this.onVisibilityChange);
+        },
+
         onVisibilityChange: function() {
             if (document.visibilityState === "hidden") scorm.commit();
         },
@@ -127,7 +133,7 @@ define([
     //Session End
 
         onWindowUnload: function() {
-            $(window).off('beforeunload unload', this._onWindowUnload);
+            this.removeEventListeners();
 
             if (!scorm.finishCalled){
                 scorm.finish();


### PR DESCRIPTION
when the course window starts unloading

see https://github.com/adaptlearning/adapt_framework/issues/1625