### PR TITLE
Fixes #1767, problem with IE 8 failing to commit tracking data

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Note that due to the data storage limitations of browser cookies, there is less 
 Currently (officially) only supports SCORM 1.2  
 
 ----------------------------
-**Version number:**  2.1.2   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.1.3   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 2.0.16+
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-spoor/graphs/contributors) 
 **Accessibility support:** n/a   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "framework": ">=2.0.16",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-spoor%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20the%20contents%20of%20the%20SCORM%20debug%20window.",

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -123,7 +123,9 @@ define([
         removeEventListeners: function() {
             $(window).off('beforeunload unload', this._onWindowUnload);
 
-            document.removeEventListener("visibilitychange", this.onVisibilityChange);
+            if (document.removeEventListener) {
+                document.removeEventListener("visibilitychange", this.onVisibilityChange);
+            }
         },
 
         onVisibilityChange: function() {


### PR DESCRIPTION
The document.removeEventListener function isn't supported in IE 8.