### PR TITLE
Resolves #2001, in preparation for v3 Spoor now listens for 'tracking…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,7 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 
 **_spoor**: (object): The Spoor object that contains values for **_isEnabled**, **_tracking**, **_reporting**, and **_advancedSettings**.
  
->**_isEnabled** (boolean): Enables/disables the **Spoor** extension. If set to `true` (the default value), the plugin will try to connect to a SCORM conformant LMS when the course is launched via *index_lms.html*. If one is not available, a 'Could not connect to LMS' error message will be displayed. This error can be avoided during course development either by setting this to `false` or - more easily - by launching the course via *index.html* or *main.html*. This latter technique is also useful if you are developing a course that could be run either from an LMS or a regular web server.
-
->>**_requireCourseCompleted** (boolean): Determines whether the learner must complete all the components in the course before the course can be marked as finished in the LMS. Acceptable values are `true` or `false`. The default is `false`.    
-
->>**_requireAssessmentPassed** (boolean): Determines whether the user must pass the course assessment, not simply complete it, before the course can be marked as finished in the LMS. Acceptable values are `true` or `false`. The default is `false`.  If this attribute and `_requireCourseCompleted` are both set to `true`, the learner must pass the course assessment as well as complete all components in order for the course can be marked as finished in the LMS.
+>>**_isEnabled** (boolean): Enables/disables the **Spoor** extension. If set to `true` (the default value), the plugin will try to connect to a SCORM conformant LMS when the course is launched via *index_lms.html*. If one is not available, a 'Could not connect to LMS' error message will be displayed. This error can be avoided during course development either by setting this to `false` or - more easily - by launching the course via *index.html* or *main.html*. This latter technique is also useful if you are developing a course that could be run either from an LMS or a regular web server.ß
 
 >>**_shouldSubmitScore** (boolean): Determines whether the numeric scores attained in assessments will be reported to the LMS. Acceptable values are `true` or `false`. The default is `false`.  
 
@@ -114,8 +110,8 @@ Note that due to the data storage limitations of browser cookies, there is less 
 Currently (officially) only supports SCORM 1.2  
 
 ----------------------------
-**Version number:**  2.1.3   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
-**Framework versions:** 2.0.16+
+**Version number:**  3.0.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Framework versions:** 3.0.0+
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-spoor/graphs/contributors) 
 **Accessibility support:** n/a   
 **RTL support:** n/a  

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 
 **_spoor**: (object): The Spoor object that contains values for **_isEnabled**, **_tracking**, **_reporting**, and **_advancedSettings**.
  
->>**_isEnabled** (boolean): Enables/disables the **Spoor** extension. If set to `true` (the default value), the plugin will try to connect to a SCORM conformant LMS when the course is launched via *index_lms.html*. If one is not available, a 'Could not connect to LMS' error message will be displayed. This error can be avoided during course development either by setting this to `false` or - more easily - by launching the course via *index.html* or *main.html*. This latter technique is also useful if you are developing a course that could be run either from an LMS or a regular web server.ß
+>>**_isEnabled** (boolean): Enables/disables the **Spoor** extension. If set to `true` (the default value), the plugin will try to connect to a SCORM conformant LMS when the course is launched via *index_lms.html*. If one is not available, a 'Could not connect to LMS' error message will be displayed. This error can be avoided during course development either by setting this to `false` or - more easily - by launching the course via *index.html*. This latter technique is also useful if you are developing a course that could be run either from an LMS or a regular web server.
 
 >>**_shouldSubmitScore** (boolean): Determines whether the numeric scores attained in assessments will be reported to the LMS. Acceptable values are `true` or `false`. The default is `false`.  
 
@@ -96,7 +96,7 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 <div float align=right><a href="#top">Back to Top</a></div>  
 
 ### Running a course without tracking while Spoor is installed  
-- Use *main.html* or *index.html* instead of *index_lms.html*.  
+- Use *index.html* instead of *index_lms.html*.  
 *OR*  
 - Set `"_isEnabled": false` in *config.json*.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "2.1.4",
+  "version": "3.0.0",
   "framework": ">=3.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-spoor%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20the%20contents%20of%20the%20SCORM%20debug%20window.",

--- a/example.json
+++ b/example.json
@@ -3,8 +3,6 @@
 	"_spoor": {
 		"_isEnabled": true,
 		"_tracking": {
-			"_requireCourseCompleted": true,
-			"_requireAssessmentPassed": false,
 			"_shouldSubmitScore": false,
 			"_shouldStoreResponses": false,
 			"_shouldRecordInteractions": true

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -155,7 +155,7 @@ define([
 				}
 			}
 
-			Adapt.offlineStorage.set("status", completionData.status.asLowerCase);
+			Adapt.offlineStorage.set("status", completionStatus);
 		},
 
 		onAssessmentComplete: function(stateModel) {

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -1,26 +1,27 @@
 define([
 	'core/js/adapt',
 	'./serializers/default',
-	'./serializers/questions'
-], function(Adapt, serializer, questions) {
+	'./serializers/questions',
+	'core/js/enums/completionStateEnum'
+], function(Adapt, serializer, questions, COMPLETION_STATE) {
 
-	//Implements Adapt session statefulness
-	
+	// Implements Adapt session statefulness
+
 	var AdaptStatefulSession = _.extend({
 
 		_config: null,
 		_shouldStoreResponses: true,
 		_shouldRecordInteractions: true,
 
-	//Session Begin
+		// Session Begin
 		initialize: function(callback) {
 			this._onWindowUnload = _.bind(this.onWindowUnload, this);
-			
+
 			this.getConfig();
 
 			this.getLearnerInfo();
-			
-			// restore state asynchronously to prevent IE8 freezes
+
+			// Restore state asynchronously to prevent IE8 freezes
 			this.restoreSessionState(_.bind(function() {
 				// still need to defer call because AdaptModel.check*Status functions are asynchronous
 				_.defer(_.bind(this.setupEventListeners, this));
@@ -30,18 +31,18 @@ define([
 
 		getConfig: function() {
 			this._config = Adapt.config.has('_spoor') ? Adapt.config.get('_spoor') : false;
-			
+
 			this._shouldStoreResponses = (this._config && this._config._tracking && this._config._tracking._shouldStoreResponses);
-			
-			// default should be to record interactions, so only avoid doing that if _shouldRecordInteractions is set to false
+
+			// Default should be to record interactions, so only avoid doing that if _shouldRecordInteractions is set to false
 			if (this._config && this._config._tracking && this._config._tracking._shouldRecordInteractions === false) {
 				this._shouldRecordInteractions = false;
 			}
 		},
 
 		/**
-		 * replace the hard-coded _learnerInfo data in _globals with the actual data from the LMS
-		 * if the course has been published from the AT, the _learnerInfo object won't exist so we'll need to create it
+		 * Replace the hard-coded _learnerInfo data in _globals with the actual data from the LMS
+		 * If the course has been published from the AT, the _learnerInfo object won't exist so we'll need to create it
 		 */
 		getLearnerInfo: function() {
 			var globals = Adapt.course.get('_globals');
@@ -69,7 +70,7 @@ define([
 
 			if (hasNoPairs) return callback();
 
-			// asynchronously restore block completion data because this has been known to be a choke-point resulting in IE8 freezes
+			// Asynchronously restore block completion data because this has been known to be a choke-point resulting in IE8 freezes
 			if (sessionPairs.completion) {
 				serializer.deserialize(sessionPairs.completion, doSynchronousPart);
 			} else {
@@ -87,7 +88,7 @@ define([
 			return sessionPairs;
 		},
 
-	//Session In Progress
+		// Session In Progress
 		setupEventListeners: function() {
 			$(window).on('beforeunload unload', this._onWindowUnload);
 
@@ -95,14 +96,16 @@ define([
 				this.listenTo(Adapt.components, 'change:_isInteractionComplete', this.onQuestionComponentComplete);
 			}
 
-			if(this._shouldRecordInteractions) {
+			if (this._shouldRecordInteractions) {
 				this.listenTo(Adapt, 'questionView:recordInteraction', this.onQuestionRecordInteraction);
 			}
 
 			this.listenTo(Adapt.blocks, 'change:_isComplete', this.onBlockComplete);
-			this.listenTo(Adapt.course, 'change:_isComplete', this.onCompletion);
-			this.listenTo(Adapt, 'assessment:complete', this.onAssessmentComplete);
-			this.listenTo(Adapt, 'app:languageChanged', this.onLanguageChanged);
+			this.listenTo(Adapt, {
+				'assessment:complete': this.onAssessmentComplete,
+				'app:languageChanged': this.onLanguageChanged,
+				'tracking:complete': this.onTrackingComplete
+			});
 		},
 
 		removeEventListeners: function () {
@@ -125,12 +128,34 @@ define([
 			this.saveSessionState();
 		},
 
-		onCompletion: function() {
-			if (!this.checkTrackingCriteriaMet()) return;
-
+		onTrackingComplete: function(completionData) {
 			this.saveSessionState();
 			
-			Adapt.offlineStorage.set("status", this._config._reporting._onTrackingCriteriaMet);
+			var completionStatus = completionData.status.asLowerCase;
+
+			// The config allows the user to override the completion state.
+			switch (completionData.status) {
+				case COMPLETION_STATE.COMPLETED:
+				case COMPLETION_STATE.PASSED: {
+					if (!this._config._reporting._onTrackingCriteriaMet) {
+						Adapt.log.warn("No value defined for '_onTrackingCriteriaMet', so defaulting to '" + completionStatus + "'");
+					} else {
+						completionStatus = this._config._reporting._onTrackingCriteriaMet;
+					}
+
+					break;
+				}
+
+				case COMPLETION_STATE.FAILED: {
+					if (!this._config._reporting._onAssessmentFailure) {
+						Adapt.log.warn("No value defined for '_onAssessmentFailure', so defaulting to '" + completionStatus + "'");
+					} else {
+						completionStatus = this._config._reporting._onAssessmentFailure;
+					}
+				}
+			}
+
+			Adapt.offlineStorage.set("status", completionData.status.asLowerCase);
 		},
 
 		onAssessmentComplete: function(stateModel) {
@@ -140,9 +165,7 @@ define([
 
 			this.submitScore(stateModel);
 
-			if (stateModel.isPass) {
-				this.onCompletion();
-			} else if (this._config && this._config._tracking._requireAssessmentPassed) {
+			if (!stateModel.isPass && Adapt.config.get('_completionCriteria')._requireAssessmentPassed) {
 				this.submitAssessmentFailed();
 			}
 		},
@@ -195,33 +218,12 @@ define([
 		},
 
 		submitAssessmentFailed: function() {
-			if (this._config && this._config._reporting.hasOwnProperty("_onAssessmentFailure")) {
-				var onAssessmentFailure = this._config._reporting._onAssessmentFailure;
-				if (onAssessmentFailure === "") return;
-					
-				Adapt.offlineStorage.set("status", onAssessmentFailure);
+			if (this._config && this._config._reporting._onAssessmentFailure) {
+				Adapt.offlineStorage.set("status", this._config._reporting._onAssessmentFailure);
 			}
 		},
-		
-		checkTrackingCriteriaMet: function() {
-			var criteriaMet = false;
 
-			if (!this._config) {
-				return false;
-			}
-
-			if (this._config._tracking._requireCourseCompleted && this._config._tracking._requireAssessmentPassed) { // user must complete all blocks AND pass the assessment
-				criteriaMet = (Adapt.course.get('_isComplete') && Adapt.course.get('_isAssessmentPassed'));
-			} else if (this._config._tracking._requireCourseCompleted) { //user only needs to complete all blocks
-				criteriaMet = Adapt.course.get('_isComplete');
-			} else if (this._config._tracking._requireAssessmentPassed) { // user only needs to pass the assessment
-				criteriaMet = Adapt.course.get('_isAssessmentPassed');
-			}
-
-			return criteriaMet;
-		},
-
-	//Session End
+		// Session End
 		onWindowUnload: function() {
 			this.removeEventListeners();
 		}

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -164,10 +164,6 @@ define([
 			this.saveSessionState();
 
 			this.submitScore(stateModel);
-
-			if (!stateModel.isPass && Adapt.config.get('_completionCriteria')._requireAssessmentPassed) {
-				this.submitAssessmentFailed();
-			}
 		},
 
 		onQuestionRecordInteraction:function(questionView) {
@@ -214,12 +210,6 @@ define([
 				Adapt.offlineStorage.set("score", stateModel.scoreAsPercent, 0, 100);
 			} else {
 				Adapt.offlineStorage.set("score", stateModel.score, 0, stateModel.maxScore);
-			}
-		},
-
-		submitAssessmentFailed: function() {
-			if (this._config && this._config._reporting._onAssessmentFailure) {
-				Adapt.offlineStorage.set("status", this._config._reporting._onAssessmentFailure);
 			}
 		},
 

--- a/properties.schema
+++ b/properties.schema
@@ -30,24 +30,6 @@
                   "required": false,
                   "title": "Tracking",
                   "properties": {
-                    "_requireCourseCompleted": {
-                      "type": "boolean",
-                      "required": false,
-                      "default": true,
-                      "title": "Course completion required",
-                      "inputType": "Checkbox",
-                      "validators": [],
-                      "help": "If enabled, the plugin will require that the user must complete all the components in the course before the course can be marked as finished in the LMS."
-                    },
-                    "_requireAssessmentPassed": {
-                      "type": "boolean",
-                      "required": false,
-                      "default": false,
-                      "title": "Assessment pass required",
-                      "inputType": "Checkbox",
-                      "validators": [],
-                      "help": "If enabled, the plugin will require that the user must pass the course assessment before the course can be marked as finished in the LMS."
-                    },
                     "_shouldSubmitScore": {
                       "type": "boolean",
                       "required": false,


### PR DESCRIPTION
…:complete'

This update to Spoor is intended for release with v3 of the framework.  The following properties have been removed:
- _requireCourseCompleted
- _requireAssessmentPassed

These are both replaced with corresponding properties on the framework's config.json, which is used to trigger the 'tracking:complete' event.