### PR TITLE
reverts changes made in #171

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Note that due to the data storage limitations of browser cookies, there is less 
 Currently (officially) only supports SCORM 1.2  
 
 ----------------------------
-**Version number:**  3.0.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  3.0.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 3.0.0+
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-spoor/graphs/contributors) 
 **Accessibility support:** n/a   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "framework": ">=3",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-spoor%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20the%20contents%20of%20the%20SCORM%20debug%20window.",

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -130,7 +130,7 @@ define([
 
 		onTrackingComplete: function(completionData) {
 			this.saveSessionState();
-			
+
 			var completionStatus = completionData.status.asLowerCase;
 
 			// The config allows the user to override the completion state.
@@ -160,7 +160,7 @@ define([
 
 		onAssessmentComplete: function(stateModel) {
 			Adapt.course.set('_isAssessmentPassed', stateModel.isPass);
-			
+
 			this.saveSessionState();
 
 			this.submitScore(stateModel);
@@ -169,14 +169,15 @@ define([
 		onQuestionRecordInteraction:function(questionView) {
 			var responseType = questionView.getResponseType();
 
-			// if responseType doesn't contain any data, assume that the question component hasn't been set up for cmi.interaction tracking
+			// If responseType doesn't contain any data, assume that the question
+			// component hasn't been set up for cmi.interaction tracking
 			if(_.isEmpty(responseType)) return;
 
 			var id = questionView.model.get('_id');
 			var response = questionView.getResponse();
 			var result = questionView.isCorrect();
 			var latency = questionView.getLatency();
-			
+
 			Adapt.offlineStorage.set("interaction", id, response, result, latency, responseType);
 		},
 
@@ -190,7 +191,7 @@ define([
 			this.reattachEventListeners();
 
 			this.saveSessionState();
-			
+
 			if (this._config._reporting && this._config._reporting._resetStatusOnLanguageChange === true) {
 				Adapt.offlineStorage.set("status", "incomplete");
 			}
@@ -210,7 +211,7 @@ define([
 		onWindowUnload: function() {
 			this.removeEventListeners();
 		}
-		
+
 	}, Backbone.Events);
 
 	return AdaptStatefulSession;

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -167,21 +167,14 @@ define([
 		},
 
 		onQuestionRecordInteraction:function(questionView) {
-			var responseType = typeof questionView.model.getResponseType === 'function' 
-				? questionView.model.getResponseType()
-				: questionView.getResponseType();
+			var responseType = questionView.getResponseType();
 
-			// If responseType doesn't contain any data, assume that the question 
-			// component hasn't been set up for cmi.interaction tracking
-			if (_.isEmpty(responseType)) return;
+			// if responseType doesn't contain any data, assume that the question component hasn't been set up for cmi.interaction tracking
+			if(_.isEmpty(responseType)) return;
 
 			var id = questionView.model.get('_id');
-			var response = typeof questionView.model.getResponse === 'function'
-				? questionView.model.getResponse()
-				: questionView.getResponse();
-			var result = typeof questionView.model.isCorrect === 'function' 
-				? questionView.model.isCorrect()
-				: questionView.isCorrect();
+			var response = questionView.getResponse();
+			var result = questionView.isCorrect();
 			var latency = questionView.getLatency();
 			
 			Adapt.offlineStorage.set("interaction", id, response, result, latency, responseType);


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/2046 by letting the compatibility code that's already present in questionView handle redirecting to the model/view version of the function as needed (as we were doing before)

note that when we come to drop that compatibility code from questionView - which will be quite a way off yet! - all that we'll need to change in spoor is to amend `onQuestionRecordInteraction` to this:
```js
var questionModel = questionView.model;
var responseType = questionModel.getResponseType();

// if responseType doesn't contain any data, assume that the question component hasn't been set up for cmi.interaction tracking
if(_.isEmpty(responseType)) return;

var id = questionModel.get('_id');
var response = questionModel.getResponse();
var result = questionModel.isCorrect();
var latency = questionView.getLatency();

Adapt.offlineStorage.set("interaction", id, response, result, latency, responseType);
```