### PR TITLE
SCORM Objectives support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 
 #### Attributes
 
-**_spoor**: (object): The Spoor object that contains values for **_isEnabled**, **_tracking**, **_reporting**, and **_advancedSettings**.
+**_spoor**: (object): The Spoor object that contains values for **_isEnabled**, **_tracking**, **_reporting**, **_advancedSettings**, and **_objectives**.
  
 >**_isEnabled** (boolean): Enables/disables the **Spoor** extension. If set to `true` (the default value), the plugin will try to connect to a SCORM conformant LMS when the course is launched via *index_lms.html*. If one is not available, a 'Could not connect to LMS' error message will be displayed. This error can be avoided during course development either by setting this to `false` or - more easily - by launching the course via *index.html* or *main.html*. This latter technique is also useful if you are developing a course that could be run either from an LMS or a regular web server.
 
@@ -97,6 +97,26 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 
 >>**_commitOnVisibilityChangeHidden** (boolean): Determines whether or not a "commit" call should be made when the [visibilityState](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState) of the course page changes to `"hidden"`. This functionality helps to ensure that tracking data is saved whenever the user switches to another tab or minimises the browser window - and is only available in [browsers that support the Page Visibility API](http://caniuse.com/#search=page%20visibility). The default is `true`.
 
+>>**_debugInteractions** (boolean): Determines whether interactions data may be written to the offline API. Useful for development purposes. See **Client Local Storage / Fake LMS / Adapt LMS Behaviour Testing**.
+
+>>**_debugObjectives** (boolean): Determines whether objectives data may be written to the offline API. Useful for development purposes. See **Client Local Storage / Fake LMS / Adapt LMS Behaviour Testing**.
+
+>**_objectives** (object): The objectives settings attribute group contains values for **_isEnabled** and **_items**.
+
+>>>**_isEnabled** (boolean): Optional. Determines whether writing objectives to the tracking API will be enabled/disabled. Defaults to `true` if not specified.
+
+>>**_items** (array): Each *item* represents an objective and contains values for **_content**, **_event**, **_id**, **_initialiseWithNotAttempted** and **_immutableStates**.
+
+>>>**_content** (array): Optional. Each *item* is an Adapt content model ID. To be used with completion-based objectives. When one of the given models is completed the objective will move to the `incomplete` state. When all given models are completed the objective will move to the `completed` state.
+
+>>>**_event** (string): Optional. The name of an event that will be triggered on the global `Adapt` object. To be used with event-based objectives. Request that the objective move to a given state by passing it as an argument when the event is triggered. The requested state defaults to `completed` if no argument is given.
+
+>>>**_id** (string): The identifier of the objective. The identifier can optionally be specified by a path relative to the global `Adapt` object. Prefix with `@@` and use dot and array notation. See `example.json`. The string must be alphanumeric. If a path is given it must resolve to an alphanumeric string.
+
+>>>**_initialiseWithNotAttempted** (boolean): Optional. Determines whether the objective state will be set to `not attempted` on first run of the course. Defaults to `false` if not specified.
+
+>>>**_immutableStates** (array): Optional. Each *item* is the name of a state. Once the objective enters any of the given states it will be locked into that state; its state will not change thereafter. Acceptable values are `completed`, `incomplete`, `passed`, `failed`, `not attempted`, `browsed`. Defaults to `["completed"]` if this property is not specified.
+
 <div float align=right><a href="#top">Back to Top</a></div>  
 
 ### Running a course without tracking while Spoor is installed  
@@ -107,14 +127,14 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 ### Client Local Storage / Fake LMS / Adapt LMS Behaviour Testing
 When **Spoor** is installed, *scorm_test_harness.html* can be used instead of *index.html* to allow the browser to store LMS states inside a browser cookie. This allows developer to test LMS specified behaviour outside of an LMS environment. If you run the command `grunt server-scorm`, this will start a local server and run the course using *scorm_test_harness.html* for you. 
 
-Note that due to the data storage limitations of browser cookies, there is less storage space available than an LMS would provide. In particular having `_shouldRecordInteractions` enabled can cause a lot of data to be written to the cookie, using up the available storage more quickly - it is advised that you disable this setting when testing via *scorm_test_harness.html*. As of v2.1.1, a browser alert will be displayed if the code detects that the cookie storage limit has been exceeded.
+Note that due to the data storage limitations of browser cookies, there is less storage space available than an LMS would provide. In particular having `_shouldRecordInteractions` enabled can cause a lot of data to be written to the cookie, using up the available storage more quickly - it is advised that you disable this setting when testing via *scorm_test_harness.html*. As of v2.1.1, a browser alert will be displayed if the code detects that the cookie storage limit has been exceeded. To temporarily override this behaviour for development purposes see `_debugInteractions` and `_debugObjectives` under `_advancedSettings`.
 
 ## Limitations
  
 Currently (officially) only supports SCORM 1.2  
 
 ----------------------------
-**Version number:**  2.1.3   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.1.4   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:** 2.0.16+
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-spoor/graphs/contributors) 
 **Accessibility support:** n/a   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "2.1.3",
+  "version": "2.1.3-bsa-0.0.1",
   "framework": ">=2.0.16",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-spoor%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20the%20contents%20of%20the%20SCORM%20debug%20window.",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "2.1.3-bsa-0.0.1",
+  "version": "2.1.4",
   "framework": ">=2.0.16",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-spoor%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20the%20contents%20of%20the%20SCORM%20debug%20window.",

--- a/example.json
+++ b/example.json
@@ -24,7 +24,51 @@
 			"_timedCommitFrequency": 10,
 			"_maxCommitRetries": 5,
 			"_commitRetryDelay": 2000,
-			"_commitOnVisibilityChangeHidden": true
-		}
+			"_commitOnVisibilityChangeHidden": true,
+            "_debugInteractions": false,
+            "_debugObjectives": false
+		},
+        "_objectives": {
+            "_isEnabled": true,
+            "_items": [
+                {
+                    "comment": "Listen for completion of the given content object. The objective ID is obtained from the content object JSON.",
+                    "_content": [
+                        "co-05"
+                    ],
+                    "_id": "@@contentObjects._byAdaptID[co-05][0]._objectiveId",
+                    "_initialiseWithNotAttempted": true,
+                    "_immutableStates": [
+                    	"completed"
+                    ]
+                },
+                {
+                    "comment": "Listen for completion of the given blocks. The objective ID is obtained from the course JSON.",
+                    "_content": [
+                        "b-40",
+                        "b-45",
+                        "b-50",
+                        "b-55",
+                        "b-60"
+                    ],
+                    "_id": "@@course._objectives._objectiveId",
+                    "_initialiseWithNotAttempted": true,
+                    "_immutableStates": [
+                    	"completed"
+                    ]
+                },
+                {
+                    "comment": "Listen for completion of the given content object. The objective ID is obtained from the content object JSON.",
+                    "_content": [
+                        "co-15"
+                    ],
+                    "_id": "@@contentObjects._byAdaptID[co-15][0]._objectiveId",
+                    "_initialiseWithNotAttempted": true,
+                    "_immutableStates": [
+                    	"completed"
+                    ]
+                }
+            ]
+        }
 	}
 }

--- a/js/adapt-objectives.js
+++ b/js/adapt-objectives.js
@@ -1,0 +1,227 @@
+define([
+	'core/js/adapt'
+], function(Adapt) {
+
+	/*
+		## Objective types
+
+		Objectives can be completion-based or event-based. A completion based objective changes state as the given content models (components, blocks, articles, content objects) are completed. State changes for event-based objectives are handled externally; allowing the behaviour of the objective to be implemented arbitrarily. Specify a completion-based objective using the property `_content` and assigning to it an array of content model IDs. An event-based objective is specified by assigning the name of the event to the `_event` property.
+
+		## Objective identifiers
+
+		Objective IDs can be given directly in config.json. Alternatively, objective IDs can be given by paths. A path uses standard dot and array notation. The path is relative to the global Adapt object. An example use of paths could be localisation; where the localised identifiers are stored with the associated JSON (e.g. contentObjects.json).
+
+		### Example objective ID paths
+
+		Prefix with @@ to specify a path and use dot and array notation. All paths are relative to the global Adapt object. For example:
+
+		@@course._objectives.objective1._id
+		@@course._objectives[0]._id
+		@@contentObjects._byAdaptID[co-05][0]._objectiveId
+
+		## Objective states
+
+		On first run of a course an objective can be optionally initialised with the state `not attempted`. Specify whether this should happen with the property `_initialiseWithNotAttempted`. How the objective state changes depends on the type of objective: for completion-based objectives the state will change as the content models are completed. The state of event-based objectives is controlled externally; typically this will be from a custom plugin. When an objective enters a new state it can be locked into this state to prevent future changes. Such states are described as immutable state. Specify these using the `_immutableStates` property. An example usage could be for completion-based objectives that once complete, should not be affected by content models being reset.
+
+		NOTES:
+			-Watching descendants of models and updating status to incomplete is an idea for future development.
+			-Modifications to spoor files: wrapper.js, adapt-offlineStorage-scorm.js, adapt-stateful-session.js, offline_wrapper_API.js
+			-Made storing interactions/objectives locally configurable (for testing purposes) (see https://github.com/adaptlearning/adapt_framework/issues/1905)
+			-Future development might add support for making the pass/fail of an assessment an objective. If SCORM 2004 is used this could utilise the cmi.objectives.n.success_status field.
+			- The changes will need to be applied to the master and legacy branches of spoor
+
+		TODO:
+	*/
+
+	var defaultImmutableStates = ['completed'];
+
+	var Objectives = _.extend({
+
+		initialize:function() {
+			// TODO: remove (testing purposes only!)
+			Adapt.resolveObjectiveId = this.resolveObjectiveId;
+
+			if (!Adapt.config.has('_spoor') || Adapt.config.get('_spoor')._isEnabled === false) return;
+			if (!Adapt.config.get('_spoor')._objectives || Adapt.config.get('_spoor')._objectives._isEnabled === false) return;
+
+			this._config = Adapt.config.get('_spoor')._objectives;
+			this._listeners = [];
+
+			this.setupItems(this._config._items);
+		},
+
+		setupItems:function(items) {
+			if (_.isEmpty(items)) return;
+
+			_.each(items, function(item) {
+				item._id = this.resolveObjectiveId(item._id);
+
+				if (!this.isObjectiveIDValid(item._id)) {
+					console.error('Objective ID', item._id, 'is invalid. Please only use alphanumeric characters');
+					return;
+				}
+
+				var status = Adapt.offlineStorage.get('objectiveCompletionStatus', item._id);
+				var immutableStates = this.getImmutableStates(item);
+
+				if (immutableStates.indexOf(status) != -1) {
+					return;
+				}
+
+				if ((status == null || status == 'unknown') && item._initialiseWithNotAttempted) {
+					Adapt.offlineStorage.set('objectiveCompletionStatus', item._id, 'not attempted');
+				}
+
+				if (!_.isEmpty(item._content)) {
+					this.setupContentCompletionListener(item);
+				} else if (!_.isEmpty(item._event)) {
+					this.setupCustomEventListener(item);
+				}
+			}, this);
+		},
+
+		// status determined externally; register handler for global event (status passed as argument to handler)
+		setupCustomEventListener:function(item) {
+			var immutableStates = this.getImmutableStates(item);
+
+			Adapt.on(item._event, check);
+
+			function check(status) {
+				var status = status || 'completed';
+
+				Adapt.offlineStorage.set('objectiveCompletionStatus', item._id, status);
+
+				if (immutableStates.indexOf(status) != -1) {
+					Adapt.off(item._event, check);
+				}
+			}
+		},
+
+		// status determined by the completion state of one or more Adapt models
+		setupContentCompletionListener:function(item) {
+			var that = this;
+			var contentModels = [];
+			var immutableStates = this.getImmutableStates(item);
+			var isComplete = function(model) {
+				return model.get('_isComplete');
+			};
+			var removeListeners = function() {
+				_.each(contentModels, function(model) {
+					model.off('change:_isComplete', checkCompletion);
+				});
+			};
+			var checkCompletion = function() {
+				var completeCount = _.filter(contentModels, isComplete).length;
+				if (completeCount == contentModels.length) {
+					that.log('objective', item._id, 'completed');
+
+					Adapt.offlineStorage.set('objectiveCompletionStatus', item._id, 'completed');
+
+					if (immutableStates.indexOf('completed') != -1) {
+						removeListeners();
+					}
+				} else if (completeCount > 0) {
+					that.log('objective', item._id, 'incomplete');
+
+					Adapt.offlineStorage.set('objectiveCompletionStatus', item._id, 'incomplete');
+				}
+			};
+
+			_.each(item._content, function(contentId) {
+				var model = Adapt.findById(contentId);
+				contentModels.push(model);
+				model.on('change:_isComplete', checkCompletion);
+				console.log('listening to completion event on', model.get('_id'));
+			});
+
+			checkCompletion();
+		},
+
+		getImmutableStates:function(item) {
+			var immutableStates = defaultImmutableStates;
+
+			if (!_.isEmpty(item._immutableStates)) immutableStates = item._immutableStates;
+
+			return immutableStates;
+		},
+
+		isObjectiveIDValid:function(id) {
+			if (!_.isString(id) || id.length == 0) return;
+
+			var match = id.match(/^[a-zA-Z0-9]*$/);
+			return match && match[0].length == id.length;
+		},
+
+		resolveObjectiveId:function(id) {
+			if (id[0] == '@' && id[1] == '@') {
+				id = id.slice(2);
+				var tokens = id.split('.');
+				var ctx = null;
+
+				_.each(tokens, function(name) {
+					ctx = resolve(ctx == null ? Adapt : ctx, name);
+				});
+
+				return ctx;
+			}
+
+			function resolve(ctx, name) {
+				var arrayPath = name.slice(-1) == ']' ? getIndices(name) : null;
+				var value;
+
+				if (arrayPath) name = arrayPath.name;
+
+				if (ctx[name]) value = ctx[name];
+				else if (ctx instanceof Backbone.Model) value = ctx.get(name);
+				else {
+					console.error('Invalid path for objective ID:', id);
+					return;
+				}
+
+				if (arrayPath) {
+					_.each(arrayPath.indices, function(index) {
+						value = value[index];
+					});
+				}
+
+				return value;
+			}
+
+			function getIndices(str) {
+			    var index = 0;
+			    var indices = [];
+
+			    while (str[index + 1] != '[') {
+			        index++;
+			    }
+
+			    var name = str.substr(0, index + 1);
+			    
+			    while (str[index + 1] == '[') {
+			        index++;
+			        var startIndex = index;
+			        while (str[index + 1] != ']') {
+			            index++;
+			        }
+			        indices.push(str.substr(startIndex + 1, index - startIndex));
+			        index++;
+			    }
+
+			    return {name:name, indices:indices};
+			}
+
+			return id;
+		},
+
+		log:function() {
+			if (Adapt.log && false) {
+				Adapt.log.info.apply(Adapt.log, arguments);
+			} else {
+				console.log.apply(console, arguments);
+			}
+		}
+
+	}, Backbone.Events);
+
+	return Objectives;
+});

--- a/js/adapt-offlineStorage-scorm.js
+++ b/js/adapt-offlineStorage-scorm.js
@@ -14,6 +14,8 @@ define([
 	Adapt.offlineStorage.initialize({
 
 		get: function(name) {
+			var args = [].slice.call(arguments, 1);
+			
 			if (name === undefined) {
 				//If not connected return just temporary store.
 				if (this.useTemporaryStore()) return temporaryStore;
@@ -39,6 +41,12 @@ define([
 
 			//Get by name
 			switch (name.toLowerCase()) {
+				case "objectivecompletionstatus":
+					return scorm.getObjectiveCompletionStatus.apply(scorm, args);
+				case "objectivesuccessstatus":
+					return scorm.getObjectiveSuccessStatus.apply(scorm, args);
+				case "objectivescore":
+					return scorm.getObjectiveScore.apply(scorm, args);
 				case "location":
 					return scorm.getLessonLocation();
 				case "score":
@@ -75,6 +83,12 @@ define([
 			}
 
 			switch (name.toLowerCase()) {
+				case "objectivecompletionstatus":
+					return scorm.setObjectiveCompletionStatus.apply(scorm, args);
+				case "objectivesuccessstatus":
+					return scorm.setObjectiveSuccessStatus.apply(scorm, args);
+				case "objectivescore":
+					return scorm.setObjectiveScore.apply(scorm, args);
 				case "interaction":
 					return scorm.recordInteraction.apply(scorm, args);
 				case "location":

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -1,8 +1,9 @@
 define([
 	'core/js/adapt',
 	'./serializers/default',
-	'./serializers/questions'
-], function(Adapt, serializer, questions) {
+	'./serializers/questions',
+	'./adapt-objectives'
+], function(Adapt, serializer, questions, objectives) {
 
 	//Implements Adapt session statefulness
 	
@@ -26,6 +27,8 @@ define([
 				_.defer(_.bind(this.setupEventListeners, this));
 				callback();
 			}, this));
+
+			objectives.initialize();
 		},
 
 		getConfig: function() {

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -533,7 +533,7 @@ define (function(require) {
 		
 		var maxLength = this.isSCORM2004() ? 250 : 255;
 
-		if(response.length > maxLength) {
+		if (response.length > maxLength) {
 			response = response.substr(0, maxLength);
 
 			this.logger.warn("ScormWrapper::recordInteractionFillIn: response data for " + id + " is longer than the maximum allowed length of " + maxLength + " characters; data will be truncated to avoid an error.");
@@ -542,6 +542,221 @@ define (function(require) {
 		var scormRecordInteraction = this.isSCORM2004() ? this.recordInteractionScorm2004 : this.recordInteractionScorm12;
 
 		scormRecordInteraction.call(this, id, response, correct, latency, type);
+	};
+
+	ScormWrapper.prototype.setObjectiveScore = function(objectiveId, score, minScore, maxScore) {
+		
+		var objectiveIndex;
+		var retVal;
+		
+		this.logger.info("ScormWrapper::setObjectiveScore: objectiveId=" + objectiveId + ", score=" + score + ", maxScore=" + maxScore + ", minScore=" + minScore);
+		
+		objectiveIndex = this.findObjectiveIndexFromID(objectiveId);
+		
+		if (objectiveIndex == -1) {
+			this.logger.info("No objective with ID " + objectiveId);
+			objectiveIndex = 0;
+		}
+		
+		this.logger.info("objectiveIndex=" + objectiveIndex);
+		
+		retVal = this.setValue("cmi.objectives." + objectiveIndex + ".id", objectiveId);
+		retVal = retVal && this.setValue("cmi.objectives." + objectiveIndex + ".score.raw", score);
+		retVal = retVal && this.setValue("cmi.objectives." + objectiveIndex + ".score.max", maxScore);
+		retVal = retVal && this.setValue("cmi.objectives." + objectiveIndex + ".score.min", minScore);
+		
+		this.logger.info("Returning " + retVal);
+		
+		return retVal;
+	};
+
+	ScormWrapper.prototype.setObjectiveCompletionStatus = function(objectiveId, status) {
+
+		var objectiveIndex;
+		var retVal;
+		
+		this.logger.info("ScormWrapper::setObjectiveCompletionStatus: objectiveId=" + objectiveId + ", status=" + status);
+		
+		objectiveIndex = this.findObjectiveIndexFromID(objectiveId);
+		
+		if (objectiveIndex == -1) {
+			this.logger.info("No objective with ID " + objectiveId);
+			objectiveIndex = 0;
+		}
+		
+		this.logger.info("objectiveIndex=" + objectiveIndex);
+		
+		retVal = this.setValue("cmi.objectives." + objectiveIndex + ".id", objectiveId);
+		retVal = retVal && this.setValue("cmi.objectives." + objectiveIndex + (this.isSCORM2004() ? ".completion_status" : ".status"), status);
+		
+		this.logger.info("Returning " + retVal);
+		
+		return retVal;
+	};
+
+	ScormWrapper.prototype.setObjectiveSuccessStatus = function(objectiveId, status) {
+
+		var objectiveIndex;
+		var retVal;
+		
+		this.logger.info("ScormWrapper::setObjectiveSuccessStatus: objectiveId=" + objectiveId + ", status=" + status);
+		
+		objectiveIndex = this.findObjectiveIndexFromID(objectiveId);
+		
+		if (objectiveIndex == -1) {
+			this.logger.info("No objective with ID " + objectiveId);
+			objectiveIndex = 0;
+		}
+		
+		this.logger.info("objectiveIndex=" + objectiveIndex);
+		
+		retVal = this.setValue("cmi.objectives." + objectiveIndex + ".id", objectiveId);
+		retVal = retVal && this.setValue("cmi.objectives." + objectiveIndex + (this.isSCORM2004() ? ".success_status" : ".status"), status);
+		
+		this.logger.info("Returning " + retVal);
+		
+		return retVal;
+	};
+
+	ScormWrapper.prototype.getObjectiveScore = function(objectiveId) {
+
+		var objectiveIndex;
+		
+		this.logger.info("ScormWrapper::getObjectiveScore: objectiveId=" + objectiveId);
+		
+		objectiveIndex = this.findObjectiveIndexFromID(objectiveId);
+		
+		if (objectiveIndex == -1) {
+			this.logger.info("No objective with ID " + objectiveId);
+			
+			return null;
+		} else {	
+			this.logger.info("objectiveIndex=" + objectiveIndex);
+			
+			return this.getValue("cmi.objectives." + objectiveIndex + ".score.raw");
+		}
+	};
+
+	ScormWrapper.prototype.getObjectiveCompletionStatus = function(objectiveId) {
+
+		var objectiveIndex;
+		var status;
+		
+		this.logger.info("ScormWrapper::getObjectiveCompletionStatus: objectiveId=" + objectiveId);
+		
+		objectiveIndex = this.findObjectiveIndexFromID(objectiveId);
+		
+		if (objectiveIndex == -1) {
+			this.logger.info("No objective with ID " + objectiveId);
+			
+			return null;
+		} else {
+			this.logger.info("objectiveIndex=" + objectiveIndex);
+			
+			status = this.getValue("cmi.objectives." + objectiveIndex + (this.isSCORM2004() ? ".completion_status" : ".status"));
+			
+			if (status == "passed" && !this.isSCORM2004()) {
+				this.logger.info("returning passed");
+				return "passed";
+			} else if (status == "failed" && !this.isSCORM2004()) {
+				this.logger.info("Returning failed");
+				return "failed";
+			} else if (status == "completed") {
+				this.logger.info("Returning completed");
+				return "completed";
+			} else if (status == "incomplete") {
+				this.logger.info("Returning incomplete");
+				return "incomplete";
+			} else if (status == "browsed") {
+				this.logger.info("Returning browsed");
+				return "browsed";
+			} else if (status == "not attempted" || status == "") {
+				this.logger.info("Returning not attempted");
+				return "not attempted";
+			} else if (status == "unknown" && this.isSCORM2004()) {
+				this.logger.info("Returning unknown");
+				return "unknown";
+			} else{
+				this.logger.warn("Got invalid objective status (" + status + ") or status not yet set for objective (" + objectiveId + ")");
+				return null;
+			}
+		}
+	};
+
+	ScormWrapper.prototype.getObjectiveSuccessStatus = function(objectiveId) {
+
+		var objectiveIndex;
+		var status;
+		
+		this.logger.info("ScormWrapper::getObjectiveSuccessStatus: objectiveId=" + objectiveId);
+		
+		objectiveIndex = this.findObjectiveIndexFromID(objectiveId);
+		
+		if (objectiveIndex == -1) {
+			this.logger.info("No objective with ID " + objectiveId);
+			
+			return null;
+		} else {
+			this.logger.info("objectiveIndex=" + objectiveIndex);
+			
+			status = this.getValue("cmi.objectives." + objectiveIndex + (this.isSCORM2004() ? ".success_status" : ".status"));
+			
+			if (status == "passed") {
+				this.logger.info("returning passed");
+				return "passed";
+			} else if (status == "failed") {
+				this.logger.info("Returning failed");
+				return "failed";
+			} else if (status == "completed" && !this.isSCORM2004()) {
+				this.logger.info("Returning completed");
+				return "completed";
+			} else if (status == "incomplete" && !this.isSCORM2004()) {
+				this.logger.info("Returning incomplete");
+				return "incomplete";
+			} else if (status == "browsed" && !this.isSCORM2004()) {
+				this.logger.info("Returning browsed");
+				return "browsed";
+			} else if ((status == "not attempted" && !this.isSCORM2004()) || status == "") {
+				this.logger.info("Returning not attempted");
+				return "not attempted";
+			} else if (status == "unknown" && this.isSCORM2004()) {
+				this.logger.info("Returning unknown");
+				return "unknown";
+			} else {
+				this.logger.warn("Got invalid objective status (" + status + ") or status not yet set for objective (" + objectiveId + ")");
+				return null;
+			}
+		}
+	};
+
+	ScormWrapper.prototype.findObjectiveIndexFromID = function(objectiveId) {
+
+		var count, temp;
+		
+		this.logger.info("ScormWrapper::findObjectiveIndexFromID");
+		
+		count = this.getValue("cmi.objectives._count");
+		
+		if (count == "") {
+			this.logger.info("Setting count to 0");
+			return 0;
+		}
+		
+		count = parseInt(count);
+		
+		this.logger.info("count=" + count);
+		
+		for (var i = 0; i < count; i++) {
+		
+			temp = this.getValue("cmi.objectives." + i + ".id");
+			
+			if (temp == objectiveId) {
+				this.logger.info("Found index of objective (" + objectiveId + ") at " + i);
+				return i;
+			}
+		}
+		
+		return count > 0 ? count : -1;
 	};
 
 	ScormWrapper.prototype.showDebugWindow = function() {

--- a/properties.schema
+++ b/properties.schema
@@ -185,6 +185,110 @@
                       "inputType": "Checkbox",
                       "validators": [],
                       "help": "If enabled, a 'commit' call will be made whenever the course window is hidden/minimised. Requires a browser that supports the 'visibilitychange' event."
+                    },
+                    "_debugInteractions": {
+                      "type": "boolean",
+                      "default": false,
+                      "title": "Debug interactions",
+                      "inputType": "Checkbox",
+                      "validators": [],
+                      "help": "If enabled, interactions data will be written to the offline API to aid debugging. N.B. this only applies to launch methods that use the offline API."
+                    },
+                    "_debugObjectives": {
+                      "type": "boolean",
+                      "default": false,
+                      "title": "Debug objectives",
+                      "inputType": "Checkbox",
+                      "validators": [],
+                      "help": "If enabled, objectives data will be written to the offline API to aid debugging. N.B. this only applies to launch methods that use the offline API."
+                    }
+                  }
+                },
+                "_objectives": {
+                  "type": "object",
+                  "required": false,
+                  "title": "Objectives",
+                  "help": "Support for SCORM cmi.objectives",
+                  "properties": {
+                    "_isEnabled": {
+                      "type": "boolean",
+                      "required": true,
+                      "default": true,
+                      "title": "Is Enabled",
+                      "inputType": "Checkbox",
+                      "validators": [],
+                      "help": "If enabled, the plugin will record objectives if any have been configured. Uncheck to switch off objectives tracking."
+                    },
+                    "_items": {
+                      "type": "array",
+                      "required": true,
+                      "title": "Objective items",
+                      "help": "A list of objectives to report back to the LMS.",
+                      "items": {
+                        "type": "object",
+                        "required": true,
+                        "properties": {
+                          "_id": {
+                            "type": "string",
+                            "required": true,
+                            "default": "",
+                            "title": "ID",
+                            "inputType": "Text",
+                            "validators": [],
+                            "help": "The string to use for the objective identifier or a path to the identifier (see documentation). The identifier is used for the cmi.objectives.[n].id field and therefore must be alphanumeric with no whitespace."
+                          },
+                          "_initialiseWithNotAttempted": {
+                            "type": "boolean",
+                            "required": true,
+                            "default": true,
+                            "title": "Initialise with 'not attempted'",
+                            "inputType": "Checkbox",
+                            "validators": [],
+                            "help": "If enabled, when the course is first launched the objective status will be set to 'not attempted'."
+                          },
+                          "_immutableStates": {
+                            "type":"array",
+                            "required": true,
+                            "title": "Immutable states",
+                            "help": "Once an objective enters one of the given states its status will not be changed thereafter.",
+                            "items": {
+                              "type": "object",
+                              "required": true,
+                              "properties": {
+                                "_status": {
+                                  "type": "string",
+                                  "required": true,
+                                  "default": "completed",
+                                  "title":"Status",
+                                  "enum": ["completed", "passed", "failed", "incomplete", "browsed", "not attempted"],
+                                  "inputType": {
+                                    "type": "Select",
+                                    "options": ["completed", "passed", "failed", "incomplete", "browsed", "not attempted"]
+                                  },
+                                  "validators": []
+                                }
+                              }
+                            }
+                          },
+                          "_content": {
+                            "type":"array",
+                            "required": false,
+                            "default": [""],
+                            "title": "Content model identifiers",
+                            "help": "Provide a list of one or more model identifiers if the objective is completion-based. When one of the listed models is completed the objective will move to the 'incomplete' state. When all listed models are completed the objective will move to the 'completed' state.",
+                            "inputType": "List"
+                          },
+                          "_event": {
+                            "type": "string",
+                            "required": false,
+                            "default": "",
+                            "title": "Event",
+                            "inputType": "Text",
+                            "validators": [],
+                            "help": "Provide a value for this property if the objective is event-based. The given string is the name of the event that should be triggered on the global Adapt object to indicate that the objective should change state. The state may be passed as an argument when the event is triggered."
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/required/offline_API_wrapper.js
+++ b/required/offline_API_wrapper.js
@@ -6,7 +6,7 @@ function createResetButton(API) {
 	$button.on("click", function() {
 		if (API) API.LMSClear();
 		alert("Status Reset");
-		window.location.reload();
+		window.location = window.location.pathname;
 	});
 }
 
@@ -24,18 +24,41 @@ function storageWarning() {
 	notificationMethod('Warning: possible cookie storage limit exceeded - tracking may malfunction');
 }
 
+function debugInteractions() {
+	if (require) Adapt = require('coreJS/adapt');
+	if (Adapt && Adapt.config && Adapt.config.has('_spoor')) {
+		if (Adapt.config.get('_spoor')._advancedSettings &&
+			Adapt.config.get('_spoor')._advancedSettings._debugInteractions === true) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function debugObjectives() {
+	if (require) Adapt = require('coreJS/adapt');
+	if (Adapt && Adapt.config && Adapt.config.has('_spoor')) {
+		if (Adapt.config.get('_spoor')._advancedSettings &&
+			Adapt.config.get('_spoor')._advancedSettings._debugObjectives === true) {
+			return true;
+		}
+	}
+	return false;
+}
+
 var API = {
 	
 	__offlineAPIWrapper:true,
 
 	LMSInitialize: function() {
-		//if (window.ISCOOKIELMS !== false) createResetButton(this);
+		if (window.ISCOOKIELMS !== false) createResetButton(this);
 		if (!API.LMSFetch()) {
 			this.data["cmi.core.lesson_status"] = "not attempted";
 			this.data["cmi.suspend_data"] = "";
 			this.data["cmi.core.student_name"] = "Surname, Sam";
 			this.data["cmi.core.student_id"] = "sam.surname@example.org";
 			this.data["cmi.interactions._count"] = 0;
+			this.data["cmi.objectives._count"] = 0;
 			API.LMSStore(true);
 		}
 		return "true";
@@ -47,20 +70,29 @@ var API = {
 		return this.data[key];
 	},
 	LMSSetValue: function(key, value) {
-		var str = 'cmi.interactions.';
+		var isInteraction = key.indexOf('cmi.interactions.') != -1;
+		var isObjective = key.indexOf('cmi.objectives') != -1;
+
+		if (isInteraction && !debugInteractions()) return "true";
+		if (isObjective && !debugObjectives()) return "true";
 
 		this.data[key] = value;
 
-		if (key.indexOf(str) != -1) {
-			var map = [];
-			var strLen = str.length;
+		if (isInteraction) setCount.call(this, key, 'cmi.interactions.');
+		if (isObjective) setCount.call(this, key, 'cmi.objectives.');
 
-			_.each(_.keys(this.data), function(key) {
-				var index = key.indexOf(str);
-				if (index != -1) map[key.substring(strLen, key.indexOf(".", strLen))] = true;
-			});
-			
-			this.data["cmi.interactions._count"] = _.compact(map).length;
+		function setCount(key, prefix) {
+			if (key.indexOf(prefix) != -1) {
+				var map = [];
+				var prefixLen = prefix.length;
+
+				_.each(_.keys(this.data), function(key) {
+					var index = key.indexOf(prefix);
+					if (index != -1) map[key.substring(prefixLen, key.indexOf(".", prefixLen))] = true;
+				});
+				
+				this.data[prefix+"_count"] = _.compact(map).length;
+			}
 		}
 		
 		API.LMSStore();
@@ -125,6 +157,7 @@ var API_1484_11 = {
 			this.data["cmi.learner_name"] = "Surname, Sam";
 			this.data["cmi.learner_id"] = "sam.surname@example.org";
 			this.data["cmi.interactions._count"] = 0;
+			this.data["cmi.objectives._count"] = 0;
 			API_1484_11.LMSStore(true);
 		}
 		return "true";
@@ -136,20 +169,29 @@ var API_1484_11 = {
 		return this.data[key];
 	},
 	SetValue: function(key, value) {
-		var str = 'cmi.interactions.';
+		var isInteraction = key.indexOf('cmi.interactions.') != -1;
+		var isObjective = key.indexOf('cmi.objectives') != -1;
+
+		if (isInteraction && !debugInteractions()) return "true";
+		if (isObjective && !debugObjectives()) return "true";
 
 		this.data[key] = value;
 
-		if (key.indexOf(str) != -1) {
-			var map = [];
-			var strLen = str.length;
+		if (isInteraction) setCount.call(this, key, 'cmi.interactions.');
+		if (isObjective) setCount.call(this, key, 'cmi.objectives.');
 
-			_.each(_.keys(this.data), function(key) {
-				var index = key.indexOf(str);
-				if (index != -1) map[key.substring(strLen, key.indexOf(".", strLen))] = true;
-			});
-			
-			this.data["cmi.interactions._count"] = _.compact(map).length;
+		function setCount(key, prefix) {
+			if (key.indexOf(prefix) != -1) {
+				var map = [];
+				var prefixLen = prefix.length;
+
+				_.each(_.keys(this.data), function(key) {
+					var index = key.indexOf(prefix);
+					if (index != -1) map[key.substring(prefixLen, key.indexOf(".", prefixLen))] = true;
+				});
+				
+				this.data[prefix+"_count"] = _.compact(map).length;
+			}
 		}
 
 		API_1484_11.LMSStore();


### PR DESCRIPTION
**N.B. this functionality is being introduced into the legacy version of spoor first. If successful it will be introduced into master.**

Objectives are implemented as being *completion-based* or *event-based*. A list of one or more Adapt models is given for a completion-based objective. As these models are completed the status of the objective changes. The functionality for completion-based objectives is built into spoor. Event-based objectives allow the state of the objective to be controlled externally (e.g. by a third party plugin). For event-based objectives it is the responsibility of the implementer to trigger a given event to request that the objective state should change.

## Objective types
Objectives can be completion-based or event-based. A completion-based objective changes state as the given content models (components, blocks, articles, content objects) are completed. State changes for event-based objectives are handled externally; allowing the behaviour of the objective to be implemented arbitrarily. Specify a completion-based objective using the property `_content` and assigning to it an array of content model IDs. An event-based objective is specified by assigning the name of the event to the `_event` property.

## Objective identifiers
Objective IDs can be given directly in `config.json`. Alternatively, objective IDs can be given by paths. A path uses standard dot and array notation. The path is relative to the global `Adapt` object. An example use of paths could be localisation; where the localised identifiers are stored with the associated JSON (e.g. `contentObjects.json`).

### Example objective ID paths
Prefix with `@@` to specify a path and use dot and array notation. All paths are relative to the global `Adapt` object. For example:
```
@@course._objectives.objective1._id
@@course._objectives[0]._id
@@contentObjects._byAdaptID[co-05][0]._objectiveId
```
## Objective states
On first run of a course an objective can be optionally initialised with the state `not attempted`. Specify whether this should happen with the property `_initialiseWithNotAttempted`. How the objective state changes depends on the type of objective: for completion-based objectives the state will change as the content models are completed. The state of event-based objectives is controlled externally; typically this will be from a custom plugin. When an objective enters a new state it can be locked into this state to prevent future changes. Such states are described as immutable. By default the completed state is immutable. Specify which states are immutable by using the `_immutableStates` property.

## Notes
Storage of interactions by the offline API was removed by this change. To allow objectives (and interactions) to be stored by the offline API for testing purposes there are two new configuration options in spoor: `_debugInteractions` and `_debugObjectives`.