### PR TITLE
Define Exit Status in Advanced Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 
 >>**_commitOnVisibilityChangeHidden** (boolean): Determines whether or not a "commit" call should be made when the [visibilityState](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState) of the course page changes to `"hidden"`. This functionality helps to ensure that tracking data is saved whenever the user switches to another tab or minimises the browser window - and is only available in [browsers that support the Page Visibility API](http://caniuse.com/#search=page%20visibility). The default is `true`.
 
->>**_exitStateIfIncomplete** (string): Determines the exit state to return if the course hasn't been completed. The default behaviour returns an empty string for SCORM 1.2 courses, or `"normal"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing!
+>>**_exitStateIfIncomplete** (string): Determines the 'exit state' (`cmi.core.exit` in SCORM 1.2, `cmi.exit` in SCORM 2004) to set if the course hasn't been completed. The default behaviour will cause the exit state to be set to an empty string for SCORM 1.2 courses, or `"suspend"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing!
 
 >>**_exitStateIfComplete** (string): Determines the exit state to return if the course hasn't been completed. The default behaviour returns an empty string for SCORM 1.2 courses, or `"logout"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing!
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 
 >>**_exitStateIfIncomplete** (string): Determines the 'exit state' (`cmi.core.exit` in SCORM 1.2, `cmi.exit` in SCORM 2004) to set if the course hasn't been completed. The default behaviour will cause the exit state to be set to an empty string for SCORM 1.2 courses, or `"suspend"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing!
 
->>**_exitStateIfComplete** (string): Determines the exit state to return if the course hasn't been completed. The default behaviour returns an empty string for SCORM 1.2 courses, or `"logout"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing!
+>>**_exitStateIfComplete** (string): Determines the 'exit state' (`cmi.core.exit` in SCORM 1.2, `cmi.exit` in SCORM 2004) to set when the course has been completed. The default behaviour will cause the exit state to be set to an empty string for SCORM 1.2 courses, or `"normal"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing! Note: if you are using SCORM 2004, you can set this to `"suspend"` to prevent the LMS from clearing all progress tracking when a previously-completed course is re-launched by the learner.
 
 <div float align=right><a href="#top">Back to Top</a></div>  
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ The attributes listed below are used in *config.json* to configure **Spoor**, an
 
 >>**_commitOnVisibilityChangeHidden** (boolean): Determines whether or not a "commit" call should be made when the [visibilityState](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState) of the course page changes to `"hidden"`. This functionality helps to ensure that tracking data is saved whenever the user switches to another tab or minimises the browser window - and is only available in [browsers that support the Page Visibility API](http://caniuse.com/#search=page%20visibility). The default is `true`.
 
+>>**_exitStateIfIncomplete** (string): Determines the exit state to return if the course hasn't been completed. The default behaviour returns an empty string for SCORM 1.2 courses, or `"normal"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing!
+
+>>**_exitStateIfComplete** (string): Determines the exit state to return if the course hasn't been completed. The default behaviour returns an empty string for SCORM 1.2 courses, or `"logout"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing!
+
 <div float align=right><a href="#top">Back to Top</a></div>  
 
 ### Running a course without tracking while Spoor is installed  

--- a/example.json
+++ b/example.json
@@ -22,7 +22,9 @@
 			"_timedCommitFrequency": 10,
 			"_maxCommitRetries": 5,
 			"_commitRetryDelay": 2000,
-			"_commitOnVisibilityChangeHidden": true
+			"_commitOnVisibilityChangeHidden": true,
+			"_exitStateIfIncomplete": "auto",
+			"_exitStateIfComplete": "auto"
 		}
 	}
 }

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -59,31 +59,31 @@ define([
 
                 scorm.setVersion(settings._scormVersion || "1.2");
 
-                if(settings.hasOwnProperty("_suppressErrors")) {
+                if(settings._suppressErrors) {
                     scorm.suppressErrors = settings._suppressErrors;
                 }
 
-                if(settings.hasOwnProperty("_commitOnStatusChange")) {
+                if(settings._commitOnStatusChange) {
                     scorm.commitOnStatusChange = settings._commitOnStatusChange;
                 }
 
-                if(settings.hasOwnProperty("_timedCommitFrequency")) {
+                if(_.isFinite(settings._timedCommitFrequency)) {
                     scorm.timedCommitFrequency = settings._timedCommitFrequency;
                 }
 
-                if(settings.hasOwnProperty("_maxCommitRetries")) {
+                if(_.isFinite(settings._maxCommitRetries)) {
                     scorm.maxCommitRetries = settings._maxCommitRetries;
                 }
 
-                if(settings.hasOwnProperty("_commitRetryDelay")) {
+                if(_.isFinite(settings._commitRetryDelay)) {
                     scorm.commitRetryDelay = settings._commitRetryDelay;
                 }
 
-                if (settings.hasOwnProperty("_exitStateIfIncomplete")) {
+                if ("_exitStateIfIncomplete" in settings) {
                     scorm.exitStateIfIncomplete = settings._exitStateIfIncomplete;
                 }
 
-                if (settings.hasOwnProperty("_exitStateIfComplete")) {
+                if ("_exitStateIfComplete" in settings) {
                     scorm.exitStateIfComplete = settings._exitStateIfComplete;
                 }
             } else {

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -78,6 +78,22 @@ define([
                 if(settings.hasOwnProperty("_commitRetryDelay")) {
                     scorm.commitRetryDelay = settings._commitRetryDelay;
                 }
+
+                if (settings.hasOwnProperty("_exitStateIfIncomplete")) {
+                    if (settings._exitStateIfIncomplete === "'' (empty string)") {
+                        scorm.exitStateIfIncomplete = "";
+                    } else {
+                        scorm.exitStateIfIncomplete = settings._exitStateIfIncomplete;
+                    }
+                }
+
+                if (settings.hasOwnProperty("_exitStateIfComplete")) {
+                    if (settings._exitStateIfComplete === "'' (empty string)") {
+                        scorm.exitStateIfComplete = "";
+                    } else {
+                        scorm.exitStateIfComplete = settings._exitStateIfComplete;
+                    }
+                }
             } else {
                 /**
                 * force use of SCORM 1.2 by default - some LMSes (SABA/Kallidus for instance) present both APIs to the SCO and, if given the choice,

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -80,19 +80,11 @@ define([
                 }
 
                 if (settings.hasOwnProperty("_exitStateIfIncomplete")) {
-                    if (settings._exitStateIfIncomplete === "'' (empty string)") {
-                        scorm.exitStateIfIncomplete = "";
-                    } else {
-                        scorm.exitStateIfIncomplete = settings._exitStateIfIncomplete;
-                    }
+                    scorm.exitStateIfIncomplete = settings._exitStateIfIncomplete;
                 }
 
                 if (settings.hasOwnProperty("_exitStateIfComplete")) {
-                    if (settings._exitStateIfComplete === "'' (empty string)") {
-                        scorm.exitStateIfComplete = "";
-                    } else {
-                        scorm.exitStateIfComplete = settings._exitStateIfComplete;
-                    }
+                    scorm.exitStateIfComplete = settings._exitStateIfComplete;
                 }
             } else {
                 /**

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -727,15 +727,11 @@ define ([
         var isComplete = completionStatus === 'completed' || completionStatus === 'passed';
         var exitState = isComplete ? this.exitStateIfComplete : this.exitStateIfIncomplete;
 
-        switch (exitState) {
-            case undefined:
-            case 'auto':
-                if (!this.isSCORM2004()) return '';
+        if (exitState !== 'auto') return exitState;
 
-                return isComplete ? 'normal' : 'suspend';
-            default:
-                return exitState;
-        }
+        if (this.isSCORM2004()) return (isComplete ? 'normal' : 'suspend');
+
+        return '';
     };
 
     return ScormWrapper;

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -725,7 +725,7 @@ define ([
     ScormWrapper.prototype.getExitState = function() {
         var completionStatus = this.scorm.data.completionStatus;
         var isIncomplete = completionStatus === 'incomplete' || completionStatus === 'not attempted';
-        var exitState = isComplete ? this.exitStateIfComplete : this.exitStateIfIncomplete;
+        var exitState = isIncomplete ? this.exitStateIfIncomplete : this.exitStateIfComplete;
 
         if (exitState !== 'auto') return exitState;
 

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -724,12 +724,12 @@ define ([
 
     ScormWrapper.prototype.getExitState = function() {
         var completionStatus = this.scorm.data.completionStatus;
-        var isComplete = completionStatus === 'completed' || completionStatus === 'passed';
+        var isIncomplete = completionStatus === 'incomplete' || completionStatus === 'not attempted';
         var exitState = isComplete ? this.exitStateIfComplete : this.exitStateIfIncomplete;
 
         if (exitState !== 'auto') return exitState;
 
-        if (this.isSCORM2004()) return (isComplete ? 'normal' : 'suspend');
+        if (this.isSCORM2004()) return (isIncomplete ? 'suspend' : 'normal');
 
         return '';
     };

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -59,7 +59,9 @@ define ([
 
         this.logger = Logger.getInstance();
         this.scorm = pipwerks.SCORM;
-        // Prevent the Pipwerks SCORM API wrapper's handling of the exit status
+        /**
+         * Prevent the Pipwerks SCORM API wrapper's handling of the exit status
+         */
         this.scorm.handleExitMode = false;
 
         this.suppressErrors = false;

--- a/properties.schema
+++ b/properties.schema
@@ -176,6 +176,32 @@
                       "inputType": "Text",
                       "validators": ["required"],
                       "help": "Sets the 'identifier' attribute in the imsmanifest.xml"
+                    },
+                    "_exitStateIfIncomplete": {
+                      "type": "string",
+                      "required": false,
+                      "default": "auto",
+                      "title": "Exit state if incomplete",
+                      "enum": ["auto", "suspend", "normal", ""],
+                      "inputType": {
+                        "type": "Select",
+                        "options": ["auto", "suspend", "normal", "'' (empty string)"]
+                      },
+                      "validators": [],
+                      "help": "What exit status to use if the course is incomplete."
+                    },
+                    "_exitStateIfComplete": {
+                      "type": "string",
+                      "required": false,
+                      "default": "auto",
+                      "title": "Exit state if complete",
+                      "enum": ["auto", "suspend", "normal", ""],
+                      "inputType": {
+                        "type": "Select",
+                        "options": ["auto", "suspend", "normal", "'' (empty string)"]
+                      },
+                      "validators": [],
+                      "help": "What exit status to use if the course is complete."
                     }
                   }
                 }

--- a/properties.schema
+++ b/properties.schema
@@ -185,7 +185,15 @@
                       "enum": ["auto", "suspend", "normal", ""],
                       "inputType": {
                         "type": "Select",
-                        "options": ["auto", "suspend", "normal", "'' (empty string)"]
+                        "options": [
+                          "auto",
+                          "suspend",
+                          "normal",
+                          {
+                            "val": "",
+                            "label": "'' (empty string)"
+                          }
+                        ]
                       },
                       "validators": [],
                       "help": "What exit status to use if the course is incomplete."
@@ -198,7 +206,15 @@
                       "enum": ["auto", "suspend", "normal", ""],
                       "inputType": {
                         "type": "Select",
-                        "options": ["auto", "suspend", "normal", "'' (empty string)"]
+                        "options": [
+                          "auto",
+                          "suspend",
+                          "normal",
+                          {
+                            "val": "",
+                            "label": "'' (empty string)"
+                          }
+                        ]
                       },
                       "validators": [],
                       "help": "What exit status to use if the course is complete."


### PR DESCRIPTION
Fixes [#2458](https://github.com/adaptlearning/adapt_framework/issues/2458)

- Add fields to advanced settings that allow the user to define exit codes when course is completed, and when it is incomplete
- Support for SCORM 1.2 and 2004