### PR TITLE
issue/2747 Added _attemptStates save and restore

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -248,7 +248,6 @@
         },
         "component": {
           "type":"object"
-          }
         }
       }
     }

--- a/properties.schema
+++ b/properties.schema
@@ -48,6 +48,15 @@
                       "validators": [],
                       "help": "If enabled, the user's responses to questions will be saved and restored in each session. Note: this setting should be enabled in the majority of cases."
                     },
+                    "_shouldStoreAttempts": {
+                      "type": "boolean",
+                      "required": false,
+                      "default": false,
+                      "title": "Store question attempt states",
+                      "inputType": "Checkbox",
+                      "validators": [],
+                      "help": "If enabled, the user's attempt states to questions will be saved and restored in each session. Note: this setting should be disabled in the majority of cases."
+                    },
                     "_shouldRecordInteractions": {
                       "type": "boolean",
                       "required": false,
@@ -239,6 +248,7 @@
         },
         "component": {
           "type":"object"
+          }
         }
       }
     }


### PR DESCRIPTION
[#2747](https://github.com/adaptlearning/adapt_framework/issues/2747)

Requires [#2748](https://github.com/adaptlearning/adapt_framework/pull/2748) to framework for testing.
Built atop of #190, the old question state serialiser couldn't handle the more complicated data structure.

#### Changed
* All question states are saved all of the time, rather than just complete questions. All states would normally only be stored by the completion of the course.
* Questions with `_isResetOnRevisit = truthy` are saved as attempt states can be more useful here. The new serialiser is much more efficient and stable and is able to capture this new information and store all of the current and new data in a smaller suspend data footprint.

#### Added
* Save and restores `_attemptStates` attributes across sessions
* Added `_spoor._tracking.__shouldStoreAttempts = false` to `config.json` to control when attempt states are saved and restored. Attempt states are not saved and restored by default.