### PR TITLE
 issue/2754-2755 Added save, serialize and deserialize

### DIFF
--- a/js/adapt-offlineStorage-scorm.js
+++ b/js/adapt-offlineStorage-scorm.js
@@ -13,6 +13,14 @@ define([
 
   Adapt.offlineStorage.initialize({
 
+    save: function() {
+      Adapt.trigger('tracking:save');
+    },
+
+    serialize: SCORMSuspendData.serialize.bind(SCORMSuspendData),
+
+    deserialize:  SCORMSuspendData.deserialize.bind(SCORMSuspendData),
+
     get: function(name) {
       if (name === undefined) {
         //If not connected return just temporary store.

--- a/js/adapt-offlineStorage-scorm.js
+++ b/js/adapt-offlineStorage-scorm.js
@@ -14,7 +14,7 @@ define([
   Adapt.offlineStorage.initialize({
 
     save: function() {
-      Adapt.trigger('tracking:save');
+      // listens to Adapt{tracking:save} event in adapt-stateful-session  
     },
 
     serialize: SCORMSuspendData.serialize.bind(SCORMSuspendData),

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -104,7 +104,8 @@ define([
       this.listenTo(Adapt, {
         'assessment:complete': this.onAssessmentComplete,
         'app:languageChanged': this.onLanguageChanged,
-        'tracking:complete': this.onTrackingComplete
+        'tracking:complete': this.onTrackingComplete,
+        'tracking:save': this.saveSessionState
       });
     },
 


### PR DESCRIPTION
[#2754](https://github.com/adaptlearning/adapt_framework/issues/2754)
#### Added
* Backend for `Adapt.offlineStorage.save()` to force state saving

[#2755](https://github.com/adaptlearning/adapt_framework/issues/2755)
#### Added
* Backend for `Adapt.offlineStorage.serialize()` and `Adapt.offlineStorage.deserialise()`

Built ontop of #190 and #192
Requires [#2757](https://github.com/adaptlearning/adapt_framework/pull/2757)
