### PR TITLE
issue/2756 Reduced data usage

### DIFF
--- a/js/adapt-offlineStorage-scorm.js
+++ b/js/adapt-offlineStorage-scorm.js
@@ -49,6 +49,12 @@ define([
           return scorm.getStudentName();
         case "learnerinfo":
           return this.getLearnerInfo();
+        case "completion":
+          const courseState = this.getCustomState('c');
+          return courseState && SCORMSuspendData.deserialize(courseState).slice(2).map(Number).map(String).join('') || '';
+        case "questions":
+          const questionsState = this.getCustomState('q');
+          return questionsState || '';
         default:
           return this.getCustomState(name);
       }

--- a/js/adapt-offlineStorage-scorm.js
+++ b/js/adapt-offlineStorage-scorm.js
@@ -38,6 +38,7 @@ define([
       if (this.useTemporaryStore()) return temporaryStore[name];
 
       //Get by name
+      let courseState;
       switch (name.toLowerCase()) {
         case "location":
           return scorm.getLessonLocation();
@@ -49,9 +50,23 @@ define([
           return scorm.getStudentName();
         case "learnerinfo":
           return this.getLearnerInfo();
+        case "coursestate":
+          courseState = this.getCustomState('c');
+          const stateArray = courseState && SCORMSuspendData.deserialize(courseState) || [];
+          return {
+            _isCourseComplete: Boolean(stateArray.slice(0, 1).map(Number)[0]),
+            _isAssessmentPassed: Boolean(stateArray.slice(1, 2).map(Number)[0]),
+            completion: stateArray.slice(2).map(Number).map(String).join('') || ''
+          };
         case "completion":
-          const courseState = this.getCustomState('c');
+          courseState = this.getCustomState('c');
           return courseState && SCORMSuspendData.deserialize(courseState).slice(2).map(Number).map(String).join('') || '';
+        case "_iscoursecomplete":
+          courseState = this.getCustomState('c');
+          return Boolean(courseState && SCORMSuspendData.deserialize(courseState).slice(0, 1).map(Number)[0]);
+        case "_isassessmentpassed":
+          courseState = this.getCustomState('c');
+          return Boolean(courseState && SCORMSuspendData.deserialize(courseState).slice(1, 2).map(Number)[0]);
         case "questions":
           const questionsState = this.getCustomState('q');
           return questionsState || '';

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -91,7 +91,8 @@ define([
       var courseState = SCORMSuspendData.serialize([
         courseComplete,
         assessmentPassed,
-      ].concat(blockCompletion.split('').map(Number).map(Boolean)));
+        ...blockCompletion.split('').map(Number).map(Boolean)
+      ]);
       var sessionPairs = {
         'c': courseState,
         'q': (this._shouldStoreResponses === true ? questions.serialize() : '')

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -87,7 +87,7 @@ define([
       var blockCompletion = serializer.serialize();
       var courseComplete = Adapt.course.get('_isComplete') || false;
       var assessmentPassed = Adapt.course.get('_isAssessmentPassed') || false;
-      Adapt.log.info(`CourseComplete: ${courseComplete}, AssessmentPassed: ${assessmentPassed}, BlockCompletion: ${blockCompletion}`);
+      Adapt.log.info(`course._isComplete: ${courseComplete}, course._isAssessmentPassed: ${assessmentPassed}, BlockCompletion: ${blockCompletion}`);
       var courseState = SCORMSuspendData.serialize([
         courseComplete,
         assessmentPassed,

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -113,6 +113,7 @@ define([
         'app:languageChanged': this.onLanguageChanged,
         'tracking:complete': this.onTrackingComplete
       });
+      this.listenTo(Adapt.course, 'change:_isComplete', this.saveSessionState);
     },
 
     removeEventListeners: function () {

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -84,13 +84,17 @@ define([
     },
 
     getSessionState: function() {
+      var blockCompletion = serializer.serialize();
+      var courseComplete = Adapt.course.get('_isComplete') || false;
+      var assessmentPassed = Adapt.course.get('_isAssessmentPassed') || false;
+      Adapt.log.info(`CourseComplete: ${courseComplete}, AssessmentPassed: ${assessmentPassed}, BlockCompletion: ${blockCompletion}`);
       var courseState = SCORMSuspendData.serialize([
-        Adapt.course.get("_isComplete") || false,
-        Adapt.course.get('_isAssessmentPassed') || false,
-      ].concat(serializer.serialize().split('').map(Number).map(Boolean)));
+        courseComplete,
+        assessmentPassed,
+      ].concat(blockCompletion.split('').map(Number).map(Boolean)));
       var sessionPairs = {
-        "c": courseState,
-        "q": (this._shouldStoreResponses === true ? questions.serialize() : "")
+        'c': courseState,
+        'q': (this._shouldStoreResponses === true ? questions.serialize() : '')
       };
       return sessionPairs;
     },


### PR DESCRIPTION
[#2756](https://github.com/adaptlearning/adapt_framework/issues/2756)
#### Changed
* Reduced data usage

Built ontop of #192  and #190 

Note:

The course state will print out in the console when changed:
`
INFO: course._isComplete: true, course._isAssessmentPassed: true, BlockCompletion: 1111111110111110101
`

In order to manually deserialize the course state from one course in another, take the suspend data log:
`
{"lang":"en","a11y":false,"b":{"a-25":"i-ooRUixFyMA"},"c":"oAOP/93B","q":"oAIRInoEHCAh/kQGHC9EAjwxEEiegQgICH-Mgw4XogEeGGRInoEJCAh/h/YAAgAADDheiAR4YP7AAEAABInoEKCAh/j9IAgYcL0QCPDD9IAhInoELCAhfh9QgGHC9EAjw-oQJE9AhgAEAAACRPQIaEBD/KwGHC9EAjwxWCRPQIcEBD/KgGHC9EAjwxUCRPQIeEBD/IwMOF6IBHhiMJE9AiAAEAAACRPQIiEBD/IwMOF6IBHhiMJE9AigAEDAAYcL0QCPDEQSJ6BFQAIGAAw4XogEeGGRInoEWAAgYADDheiAR4YP7AAEAABInoEXAAgYADDheiAR4YfpACJE9AjAAEDAAYcL0QCPD6hA","captions":"en","a":{"a-15":"hRfRCQQggAonqIkOIaQ8SChQoUA"}}
`

Extract `"oAOP/93B"` from value `c`. Run it through `Adapt.offlineStorage.deserialize("oAOP/93B")`, it will output:
`
[true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true, true, false, true, true, true, false, false, false, false, false, true]
`

This is equivalent to `[_isCourseComplete, _isAssessmentPassed, block[0]._isComplete, block[1]._isComplete, block[2]._isComplete...]`

Calling `Adapt.offlineStore.get('coursestate')`, `Adapt.offlineStore.get('completion')`, `Adapt.offlineStore.get('_isCourseComplete')` and `Adapt.offlineStore.get('_isAssessmentPassed')`  inside a running course will elicit the appropriate states accordingly.