### PR TITLE
issue/2910 Re-added _shouldStoreResponses=false and _shouldStoreAttempts

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -106,8 +106,8 @@ define([
           _isAssessmentPassed
         });
       }
-      if (sessionPairs.q && this._shouldStoreResponses) {
-        this._componentSerializer.deserialize(sessionPairs.q);
+      if (sessionPairs.q) {
+        this._componentSerializer.deserialize(sessionPairs.q, this._shouldStoreResponses);
       }
     }
 
@@ -138,9 +138,7 @@ define([
         Boolean(Adapt.course.get('_isComplete')),
         Boolean(Adapt.course.get('_isAssessmentPassed'))
       ]);
-      const componentStates = (this._shouldStoreResponses === true) ?
-        this._componentSerializer.serialize() :
-        '';
+      const componentStates = this._componentSerializer.serialize(this._shouldStoreResponses);
       const sessionPairs = {
         'c': courseState,
         'q': componentStates

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -14,6 +14,7 @@ define([
       this._trackingIdType = 'block';
       this._componentSerializer = null;
       this._shouldStoreResponses = true;
+      this._shouldStoreAttempts = false;
       this._shouldRecordInteractions = true;
       this.beginSession();
     }
@@ -30,6 +31,7 @@ define([
       if (!config) return;
       const tracking = config._tracking;
       this._shouldStoreResponses = (tracking && tracking._shouldStoreResponses);
+      this._shouldStoreAttempts = (tracking && tracking._shouldStoreAttempts);
       // Default should be to record interactions, so only avoid doing that if
       // _shouldRecordInteractions is set to false
       if (tracking && tracking._shouldRecordInteractions === false) {
@@ -107,7 +109,7 @@ define([
         });
       }
       if (sessionPairs.q) {
-        this._componentSerializer.deserialize(sessionPairs.q, this._shouldStoreResponses);
+        this._componentSerializer.deserialize(sessionPairs.q);
       }
     }
 
@@ -138,7 +140,7 @@ define([
         Boolean(Adapt.course.get('_isComplete')),
         Boolean(Adapt.course.get('_isAssessmentPassed'))
       ]);
-      const componentStates = this._componentSerializer.serialize(this._shouldStoreResponses);
+      const componentStates = this._componentSerializer.serialize(this._shouldStoreResponses, this._shouldStoreAttempts);
       const sessionPairs = {
         'c': courseState,
         'q': componentStates

--- a/js/serializers/ComponentSerializer.js
+++ b/js/serializers/ComponentSerializer.js
@@ -10,7 +10,7 @@ define([
     }
 
     serialize(shouldStoreResponses, shouldStoreAttempts) {
-      if (shouldStoreAttempts || !shouldStoreResponses) {
+      if (shouldStoreAttempts && !shouldStoreResponses) {
         Adapt.log.warnOnce(`SPOOR configuration error, cannot use '_shouldStoreAttempts' without '_shouldStoreResponses'`);
       }
       const states = [];


### PR DESCRIPTION
[#2910](https://github.com/adaptlearning/adapt_framework/issues/2910)

### Fixed
* Re-added `_shouldStoreResponses: false` to keep `_isComplete` values
* Re-added `_shouldStoreAttempts: false` such that it can be disabled
* Warns with conflicting `_shouldStoreAttempts: true` and `_shouldStoreResponses: false`
* Derives the deserialization `_shouldStoreResponses` from the saved data to allow correct deserialization of existing data
* Skips restoration of missing tracking ids