### PR TITLE
issue/2915 Re-added Logger global reference for debug window

### DIFF
--- a/js/scorm/logger.js
+++ b/js/scorm/logger.js
@@ -69,6 +69,7 @@ define(function() {
   Logger.LOG_TYPE_ERROR = 2;
   Logger.LOG_TYPE_DEBUG = 3;
 
-  return Logger;
+  // Assign global reference for debug window
+  return (window.Logger = Logger);
 
 });


### PR DESCRIPTION
[#2915](https://github.com/adaptlearning/adapt_framework/issues/2915)

### Fixed
* Global reference to Logger class