### PR TITLE
Allow _commitOnStatusChange setting to be false

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -54,7 +54,7 @@ define([
       if (settings._suppressErrors) {
         this.scorm.suppressErrors = settings._suppressErrors;
       }
-      if (settings._commitOnStatusChange) {
+      if (settings._commitOnStatusChange === false) {
         this.scorm.commitOnStatusChange = settings._commitOnStatusChange;
       }
       if (settings._commitOnAnyChange) {

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -51,13 +51,13 @@ define([
         this.scorm.showDebugWindow();
       }
       this.scorm.setVersion(settings._scormVersion || '1.2');
-      if (settings._suppressErrors) {
+      if (_.isBoolean(settings._suppressErrors)) {
         this.scorm.suppressErrors = settings._suppressErrors;
       }
-      if (settings._commitOnStatusChange === false) {
+      if (_.isBoolean(settings._commitOnStatusChange)) {
         this.scorm.commitOnStatusChange = settings._commitOnStatusChange;
       }
-      if (settings._commitOnAnyChange) {
+      if (_.isBoolean(settings._commitOnAnyChange)) {
         this.scorm.commitOnAnyChange = settings._commitOnAnyChange;
       }
       if (_.isFinite(settings._timedCommitFrequency)) {


### PR DESCRIPTION
When publishing a course with Spoor and the setting _commitOnStatusChange set to false, it is not picked up and set during runtime.

It appears as though the if statement around the setting assignment only checks for true values, and as the default value is already true[1], it can never be set to false.

This got us in our older LMS platform which requires this setting to be set to false.

fixes https://github.com/adaptlearning/adapt_framework/issues/2943

[1] https://github.com/adaptlearning/adapt-contrib-spoor/blob/master/js/scorm/wrapper.js#L31