### PR TITLE
fixes/improvements to new error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note that due to the data storage limitations of browser cookies, there is less 
 Currently (officially) only supports SCORM 1.2  
 
 ----------------------------
-**Version number:**  3.5.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
+**Version number:**  3.6.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
 **Framework versions:** 5.5+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-spoor/graphs/contributors)  
 **Accessibility support:** n/a  

--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ When **Spoor** is installed, *scorm_test_harness.html* can be used instead of *i
 
 Note that due to the data storage limitations of browser cookies, there is less storage space available than an LMS would provide. In particular having `_shouldRecordInteractions` enabled can cause a lot of data to be written to the cookie, using up the available storage more quickly - it is advised that you disable this setting when testing via *scorm_test_harness.html*. As of v2.1.1, a browser alert will be displayed if the code detects that the cookie storage limit has been exceeded.
 
+### SCORM Error Messages  
+As of v3.6.0 it's possible to amend and/or translate the error messages that are shown by this extension whenever an LMS error is encountered. See [*example.json*](https://github.com/adaptlearning/adapt-contrib-spoor/blob/master/example.json) for the data that needs to be added to course/_lang_/course.json
+
+Note that you only need to include those you want to amend/translate. 
+
+These error messages can also be amended via the Adapt Authoring Tool - but must be supplied in JSON format. For example, if you wanted to translate the 'could not connect to LMS' error into French, you would added the following into the 'Error messages' field under Project settings > Extensions > Spoor (SCORM):
+```json
+"title": "Une erreur s'est produite",
+"CLIENT_COULD_NOT_CONNECT": "La connexion avec la plate-forme de formation n'a pas pu être établie."
+```
+
 ## Limitations
  
 Currently (officially) only supports SCORM 1.2  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "framework": ">=5.5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/example.json
+++ b/example.json
@@ -32,7 +32,8 @@
     // to be added to course/en/course.json
     "_spoor": {
         "_messages": {
-          "title": "WARNING",
+          "title": "An error has occurred",
+          "pressOk": "Press 'OK' to view detailed debug information to send to technical support.",
           "CLIENT_COULD_NOT_CONNECT": "Course could not connect to the LMS",
           "SERVER_STATUS_UNSUPPORTED": "ScormWrapper::getStatus: invalid lesson status '{{status}}' received from LMS",
           "CLIENT_STATUS_UNSUPPORTED": "ScormWrapper::setStatus: the status '{{status}}' is not supported.",

--- a/example.json
+++ b/example.json
@@ -29,19 +29,19 @@
         }
     }
 
-    // to be added to course/en/course.json
+    // to be added to course/en/course.json (note: you only need to add the ones you want to change/translate)
     "_spoor": {
         "_messages": {
-          "title": "An error has occurred",
-          "pressOk": "Press 'OK' to view detailed debug information to send to technical support.",
-          "CLIENT_COULD_NOT_CONNECT": "Course could not connect to the LMS",
-          "SERVER_STATUS_UNSUPPORTED": "ScormWrapper::getStatus: invalid lesson status '{{status}}' received from LMS",
-          "CLIENT_STATUS_UNSUPPORTED": "ScormWrapper::setStatus: the status '{{status}}' is not supported.",
-          "CLIENT_COULD_NOT_COMMIT": "Course could not commit data to the LMS\nError {{code}}: {{info}}\nLMS Error Info: {{diagnosticInfo}}",
-          "CLIENT_NOT_CONNECTED": "Course is not connected to the LMS",
-          "CLIENT_COULD_NOT_FINISH": "Course could not finish",
-          "CLIENT_COULD_NOT_GET_PROPERTY": "Course could not get {{property}}\nError Info: {{info}}\nLMS Error Info: {{diagnosticInfo}}",
-          "CLIENT_COULD_NOT_SET_PROPERTY": "Course could not set {{property}} to {{value}}\nError Info: {{info}}\nLMS Error Info: {{diagnosticInfo}}",
-          "CLIENT_INVALID_CHOICE_VALUE": "Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2"
+            "title": "An error has occurred",
+            "pressOk": "Press 'OK' to view detailed debug information to send to technical support.",
+            "CLIENT_COULD_NOT_CONNECT": "The course could not connect to the LMS",
+            "SERVER_STATUS_UNSUPPORTED": "An invalid lesson status of '{{{status}}}' was received from LMS",
+            "CLIENT_STATUS_UNSUPPORTED": "The status '{{{status}}}' is not supported.",
+            "CLIENT_COULD_NOT_COMMIT": "There was a problem saving data to the LMS\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}",
+            "CLIENT_NOT_CONNECTED": "The course is not connected to the LMS",
+            "CLIENT_COULD_NOT_FINISH": "The course was unable to finish the LMS session",
+            "CLIENT_COULD_NOT_GET_PROPERTY": "Unable to get the value of {{property}} from the LMS\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}",
+            "CLIENT_COULD_NOT_SET_PROPERTY": "Unable to set {{property}} to: {{{value}}}\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}",
+            "CLIENT_INVALID_CHOICE_VALUE": "Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2"
         }
-      }
+    }

--- a/example.json
+++ b/example.json
@@ -41,6 +41,6 @@
           "CLIENT_COULD_NOT_FINISH": "Course could not finish",
           "CLIENT_COULD_NOT_GET_PROPERTY": "Course could not get {{property}}\nError Info: {{info}}\nLMS Error Info: {{diagnosticInfo}}",
           "CLIENT_COULD_NOT_SET_PROPERTY": "Course could not set {{property}} to {{value}}\nError Info: {{info}}\nLMS Error Info: {{diagnosticInfo}}",
-          "CLIENT_INVALID_CHOICE_VALUE": "Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2: {{value}}"
+          "CLIENT_INVALID_CHOICE_VALUE": "Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2"
         }
       }

--- a/example.json
+++ b/example.json
@@ -34,13 +34,13 @@
         "_messages": {
             "title": "An error has occurred",
             "pressOk": "Press 'OK' to view detailed debug information to send to technical support.",
-            "CLIENT_COULD_NOT_CONNECT": "The course could not connect to the LMS",
-            "SERVER_STATUS_UNSUPPORTED": "An invalid lesson status of '{{{status}}}' was received from LMS",
+            "CLIENT_COULD_NOT_CONNECT": "The course could not connect to the Learning Management System",
+            "SERVER_STATUS_UNSUPPORTED": "An invalid lesson status of '{{{status}}}' was received from Learning Management System",
             "CLIENT_STATUS_UNSUPPORTED": "The status '{{{status}}}' is not supported.",
-            "CLIENT_COULD_NOT_COMMIT": "There was a problem saving data to the LMS\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}",
-            "CLIENT_NOT_CONNECTED": "The course is not connected to the LMS",
-            "CLIENT_COULD_NOT_FINISH": "The course was unable to finish the LMS session",
-            "CLIENT_COULD_NOT_GET_PROPERTY": "Unable to get the value of {{property}} from the LMS\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}",
+            "CLIENT_COULD_NOT_COMMIT": "There was a problem saving data to the Learning Management System\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}",
+            "CLIENT_NOT_CONNECTED": "The course is not connected to the Learning Management System",
+            "CLIENT_COULD_NOT_FINISH": "The course was unable to terminate the learning session",
+            "CLIENT_COULD_NOT_GET_PROPERTY": "Unable to get the value of {{property}} from the Learning Management System\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}",
             "CLIENT_COULD_NOT_SET_PROPERTY": "Unable to set {{property}} to: {{{value}}}\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}",
             "CLIENT_INVALID_CHOICE_VALUE": "Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2"
         }

--- a/js/scorm/error.js
+++ b/js/scorm/error.js
@@ -12,24 +12,24 @@ define(function() {
   ScormError.CLIENT_COULD_NOT_CONNECT = 'CLIENT_COULD_NOT_CONNECT';
   ScormError.SERVER_STATUS_UNSUPPORTED = 'SERVER_STATUS_UNSUPPORTED'; // status
   ScormError.CLIENT_STATUS_UNSUPPORTED = 'CLIENT_STATUS_UNSUPPORTED'; // status
-  ScormError.CLIENT_COULD_NOT_COMMIT = 'CLIENT_COULD_NOT_COMMIT'; // code, info, diagnosticInfo
+  ScormError.CLIENT_COULD_NOT_COMMIT = 'CLIENT_COULD_NOT_COMMIT'; // errorCode, errorInfo, diagnosticInfo
   ScormError.CLIENT_NOT_CONNECTED = 'CLIENT_NOT_CONNECTED';
   ScormError.CLIENT_COULD_NOT_FINISH = 'CLIENT_COULD_NOT_FINISH';
-  ScormError.CLIENT_COULD_NOT_GET_PROPERTY = 'CLIENT_COULD_NOT_GET_PROPERTY'; // property, info, diagnosticInfo
-  ScormError.CLIENT_COULD_NOT_SET_PROPERTY = 'CLIENT_COULD_NOT_SET_PROPERTY'; // property, value, info, diagnosticInfo
-  ScormError.CLIENT_INVALID_CHOICE_VALUE = 'CLIENT_INVALID_CHOICE_VALUE'; // value
+  ScormError.CLIENT_COULD_NOT_GET_PROPERTY = 'CLIENT_COULD_NOT_GET_PROPERTY'; // property, errorCode, errorInfo, diagnosticInfo
+  ScormError.CLIENT_COULD_NOT_SET_PROPERTY = 'CLIENT_COULD_NOT_SET_PROPERTY'; // property, value, errorCode, errorInfo, diagnosticInfo
+  ScormError.CLIENT_INVALID_CHOICE_VALUE = 'CLIENT_INVALID_CHOICE_VALUE';
 
   ScormError.defaultMessages = {
     title: 'An error has occurred',
     pressOk: `Press 'OK' to view detailed debug information to send to technical support.`,
-    CLIENT_COULD_NOT_CONNECT: 'Course could not connect to the LMS',
-    SERVER_STATUS_UNSUPPORTED: `ScormWrapper::getStatus: invalid lesson status '{{status}}' received from LMS`,
-    CLIENT_STATUS_UNSUPPORTED: `ScormWrapper::setStatus: the status '{{status}}' is not supported.`,
-    CLIENT_COULD_NOT_COMMIT: 'Course could not commit data to the LMS\nError {{code}}: {{info}}\nLMS Error Info: {{diagnosticInfo}}',
-    CLIENT_NOT_CONNECTED: 'Course is not connected to the LMS',
-    CLIENT_COULD_NOT_FINISH: 'Course could not finish',
-    CLIENT_COULD_NOT_GET_PROPERTY: 'Course could not get {{property}}\nError Info: {{info}}\nLMS Error Info: {{diagnosticInfo}}',
-    CLIENT_COULD_NOT_SET_PROPERTY: 'Course could not set {{property}} to {{value}}\nError Info: {{info}}\nLMS Error Info: {{diagnosticInfo}}',
+    CLIENT_COULD_NOT_CONNECT: 'The course could not connect to the LMS',
+    SERVER_STATUS_UNSUPPORTED: `An invalid lesson status of '{{{status}}}' was received from LMS`,
+    CLIENT_STATUS_UNSUPPORTED: `The status '{{{status}}}' is not supported.`,
+    CLIENT_COULD_NOT_COMMIT: 'There was a problem saving data to the LMS\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}',
+    CLIENT_NOT_CONNECTED: 'The course is not connected to the LMS',
+    CLIENT_COULD_NOT_FINISH: 'The course was unable to finish the LMS session',
+    CLIENT_COULD_NOT_GET_PROPERTY: 'Unable to get the value of {{property}} from the LMS\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}',
+    CLIENT_COULD_NOT_SET_PROPERTY: `Unable to set {{property}} to: '{{{value}}}'\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}`,
     CLIENT_INVALID_CHOICE_VALUE: 'Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2'
   };
 

--- a/js/scorm/error.js
+++ b/js/scorm/error.js
@@ -20,7 +20,8 @@ define(function() {
   ScormError.CLIENT_INVALID_CHOICE_VALUE = 'CLIENT_INVALID_CHOICE_VALUE'; // value
 
   ScormError.defaultMessages = {
-    title: 'WARNING',
+    title: 'An error has occurred',
+    pressOk: `Press 'OK' to view detailed debug information to send to technical support.`,
     CLIENT_COULD_NOT_CONNECT: 'Course could not connect to the LMS',
     SERVER_STATUS_UNSUPPORTED: `ScormWrapper::getStatus: invalid lesson status '{{status}}' received from LMS`,
     CLIENT_STATUS_UNSUPPORTED: `ScormWrapper::setStatus: the status '{{status}}' is not supported.`,

--- a/js/scorm/error.js
+++ b/js/scorm/error.js
@@ -22,13 +22,13 @@ define(function() {
   ScormError.defaultMessages = {
     title: 'An error has occurred',
     pressOk: `Press 'OK' to view detailed debug information to send to technical support.`,
-    CLIENT_COULD_NOT_CONNECT: 'The course could not connect to the LMS',
-    SERVER_STATUS_UNSUPPORTED: `An invalid lesson status of '{{{status}}}' was received from LMS`,
+    CLIENT_COULD_NOT_CONNECT: 'The course could not connect to the Learning Management System',
+    SERVER_STATUS_UNSUPPORTED: `An invalid lesson status of '{{{status}}}' was received from Learning Management System`,
     CLIENT_STATUS_UNSUPPORTED: `The status '{{{status}}}' is not supported.`,
-    CLIENT_COULD_NOT_COMMIT: 'There was a problem saving data to the LMS\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}',
-    CLIENT_NOT_CONNECTED: 'The course is not connected to the LMS',
-    CLIENT_COULD_NOT_FINISH: 'The course was unable to finish the LMS session',
-    CLIENT_COULD_NOT_GET_PROPERTY: 'Unable to get the value of {{property}} from the LMS\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}',
+    CLIENT_COULD_NOT_COMMIT: 'There was a problem saving data to the Learning Management System\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}',
+    CLIENT_NOT_CONNECTED: 'The course is not connected to the Learning Management System',
+    CLIENT_COULD_NOT_FINISH: 'The course was unable to terminate the learning session',
+    CLIENT_COULD_NOT_GET_PROPERTY: 'Unable to get the value of {{property}} from the Learning Management System\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}',
     CLIENT_COULD_NOT_SET_PROPERTY: `Unable to set {{property}} to: '{{{value}}}'\n\nError: {{errorCode}} - {{{errorInfo}}}\nLMS Error Info: {{{diagnosticInfo}}}`,
     CLIENT_INVALID_CHOICE_VALUE: 'Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2'
   };

--- a/js/scorm/error.js
+++ b/js/scorm/error.js
@@ -29,7 +29,7 @@ define(function() {
     CLIENT_COULD_NOT_FINISH: 'Course could not finish',
     CLIENT_COULD_NOT_GET_PROPERTY: 'Course could not get {{property}}\nError Info: {{info}}\nLMS Error Info: {{diagnosticInfo}}',
     CLIENT_COULD_NOT_SET_PROPERTY: 'Course could not set {{property}} to {{value}}\nError Info: {{info}}\nLMS Error Info: {{diagnosticInfo}}',
-    CLIENT_INVALID_CHOICE_VALUE: 'Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2: {{value}}'
+    CLIENT_INVALID_CHOICE_VALUE: 'Numeric choice/matching response elements must use a value from 0 to 35 in SCORM 1.2'
   };
 
   return ScormError;

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -427,11 +427,10 @@ define([
             errorInfo: this.scorm.debug.getInfo(errorCode),
             diagnosticInfo: this.scorm.debug.getDiagnosticInfo(errorCode)
           }));
-        } else {
-          this.logger.warn(`ScormWrapper::setValue: LMS reported that the 'set' call failed but then said there was no error!`);
+          return success;
         }
+        this.logger.warn(`ScormWrapper::setValue: LMS reported that the 'set' call failed but then said there was no error!`);
       }
-
 
       if (this.commitOnAnyChange) this.debouncedCommit();
 

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -385,17 +385,19 @@ define([
       const value = this.scorm.get(property);
       const errorCode = this.scorm.debug.getCode();
 
-      if (errorCode !== 0) {
-        if (errorCode === 403) {
+      switch (errorCode) {
+        case 0:
+          break;
+        case 403:
           this.logger.warn('ScormWrapper::getValue: data model element not initialized');
-        } else {
+          break;
+        default:
           this.handleError(new ScormError(CLIENT_COULD_NOT_GET_PROPERTY, {
             property,
             errorCode,
             errorInfo: this.scorm.debug.getInfo(errorCode),
             diagnosticInfo: this.scorm.debug.getDiagnosticInfo(errorCode)
           }));
-        }
       }
       this.logger.debug(`ScormWrapper::getValue: returning ${value}`);
       return value + '';

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -492,6 +492,13 @@ define([
         return;
       }
 
+      if ('value' in error.data) {
+        // because some browsers (e.g. Firefox) don't like displaying very long strings in the window.confirm dialog
+        if (error.data.value.length && error.data.value.length > 80) error.data.value = error.data.value.slice(0, 80) + '...';
+        // if the value being set is an empty string, ensure it displays in the error as ''
+        if (error.data.value === '') error.data.value = `''`;
+      }
+
       const config = Adapt.course.get('_spoor');
       const messages = Object.assign({}, ScormError.defaultMessages, config && config._messages);
       const message = Handlebars.compile(messages[error.name])(error.data);

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -500,7 +500,7 @@ define([
         case CLIENT_COULD_NOT_CONNECT:
           Adapt.notify.popup({
             _isCancellable: false,
-            title: errorMessages['title'],
+            title: messages.title,
             body: message
           });
           return;

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -292,8 +292,8 @@ define([
 
       const errorCode = this.scorm.debug.getCode();
       this.handleError(new ScormError(CLIENT_COULD_NOT_COMMIT, {
-        code: errorCode,
-        info: this.scorm.debug.getInfo(errorCode),
+        errorCode,
+        errorInfo: this.scorm.debug.getInfo(errorCode),
         diagnosticInfo: this.scorm.debug.getDiagnosticInfo(errorCode)
       }));
     }
@@ -391,7 +391,8 @@ define([
         } else {
           this.handleError(new ScormError(CLIENT_COULD_NOT_GET_PROPERTY, {
             property: property,
-            info: this.scorm.debug.getInfo(errorCode),
+            code: errorCode,
+            errorInfo: this.scorm.debug.getInfo(errorCode),
             diagnosticInfo: this.scorm.debug.getDiagnosticInfo(errorCode)
           }));
         }
@@ -414,18 +415,16 @@ define([
       }
 
       const success = this.scorm.set(property, value);
-      const errorCode = this.scorm.debug.getCode();
-
       if (!success) {
-      /**
-       * Some LMSes have an annoying tendency to return false from a set call even when it actually worked fine.
-       * So, we should throw an error _only_ if there was a valid error code...
-       */
+        // Some LMSes have an annoying tendency to return false from a set call even when it actually worked fine.
+        // So we should only throw an error if there was a valid error code...
+        const errorCode = this.scorm.debug.getCode();
         if (errorCode !== 0) {
           this.handleError(new ScormError(CLIENT_COULD_NOT_SET_PROPERTY, {
-            property: property,
-            value: value,
-            info: this.scorm.debug.getInfo(errorCode),
+            property,
+            value,
+            errorCode,
+            errorInfo: this.scorm.debug.getInfo(errorCode),
             diagnosticInfo: this.scorm.debug.getDiagnosticInfo(errorCode)
           }));
         } else {

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -389,6 +389,8 @@ define([
         case 0:
           break;
         case 403:
+          // 403 errors are common (and normal) when targetting SCORM 2004 - they are triggered on any
+          // attempt to get the value of a data model element that hasn't yet been assigned a value.
           this.logger.warn('ScormWrapper::getValue: data model element not initialized');
           break;
         default:

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -521,7 +521,7 @@ define([
 
     recordInteractionScorm12(id, response, correct, latency, type) {
 
-      id = this.trim(id);
+      id = id.trim();
 
       const cmiPrefix = `cmi.interactions.${this.getInteractionCount()}`;
 
@@ -535,7 +535,7 @@ define([
 
     recordInteractionScorm2004(id, response, correct, latency, type) {
 
-      id = this.trim(id);
+      id = id.trim();
 
       const cmiPrefix = `cmi.interactions.${this.getInteractionCount()}`;
 
@@ -699,10 +699,6 @@ define([
       }
 
       return numToPad.slice(-padBy);
-    }
-
-    trim(str) {
-      return str.replace(/^\s*|\s*$/g, '');
     }
 
     isSCORM2004() {

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -214,37 +214,37 @@ define([
       return this.getValue(this.isSCORM2004() ? 'cmi.score.raw' : 'cmi.core.score.raw');
     }
 
-    setScore(_score, _minScore = 0, _maxScore = 100) {
+    setScore(score, minScore = 0, maxScore = 100) {
       if (this.isSCORM2004()) {
-        this.setValue('cmi.score.raw', _score);
-        this.setValue('cmi.score.min', _minScore);
-        this.setValue('cmi.score.max', _maxScore);
+        this.setValue('cmi.score.raw', score);
+        this.setValue('cmi.score.min', minScore);
+        this.setValue('cmi.score.max', maxScore);
 
-        const range = _maxScore - _minScore;
-        const scaledScore = ((_score - _minScore) / range).toFixed(7);
+        const range = maxScore - minScore;
+        const scaledScore = ((score - minScore) / range).toFixed(7);
         this.setValue('cmi.score.scaled', scaledScore);
         return;
       }
       // SCORM 1.2
-      this.setValue('cmi.core.score.raw', _score);
-      if (this.isSupported('cmi.core.score.min')) this.setValue('cmi.core.score.min', _minScore);
-      if (this.isSupported('cmi.core.score.max')) this.setValue('cmi.core.score.max', _maxScore);
+      this.setValue('cmi.core.score.raw', score);
+      if (this.isSupported('cmi.core.score.min')) this.setValue('cmi.core.score.min', minScore);
+      if (this.isSupported('cmi.core.score.max')) this.setValue('cmi.core.score.max', maxScore);
     }
 
     getLessonLocation() {
       return this.getValue(this.isSCORM2004() ? 'cmi.location' : 'cmi.core.lesson_location');
     }
 
-    setLessonLocation(_location) {
-      this.setValue(this.isSCORM2004() ? 'cmi.location' : 'cmi.core.lesson_location', _location);
+    setLessonLocation(location) {
+      this.setValue(this.isSCORM2004() ? 'cmi.location' : 'cmi.core.lesson_location', location);
     }
 
     getSuspendData() {
       return this.getValue('cmi.suspend_data');
     }
 
-    setSuspendData(_data) {
-      this.setValue('cmi.suspend_data', _data);
+    setSuspendData(data) {
+      this.setValue('cmi.suspend_data', data);
     }
 
     getStudentName() {
@@ -255,13 +255,13 @@ define([
       return this.getValue(this.isSCORM2004() ? 'cmi.learner_id' : 'cmi.core.student_id');
     }
 
-    setLanguage(_lang) {
+    setLanguage(lang) {
       if (this.isSCORM2004()) {
-        this.setValue('cmi.learner_preference.language', _lang);
+        this.setValue('cmi.learner_preference.language', lang);
         return;
       }
       if (this.isSupported('cmi.student_preference.language')) {
-        this.setValue('cmi.student_preference.language', _lang);
+        this.setValue('cmi.student_preference.language', lang);
       }
     }
 
@@ -369,8 +369,8 @@ define([
 
     // ****************************** private methods ******************************
 
-    getValue(_property) {
-      this.logger.debug(`ScormWrapper::getValue: _property=${_property}`);
+    getValue(property) {
+      this.logger.debug(`ScormWrapper::getValue: _property=${property}`);
 
       if (this.finishCalled) {
         this.logger.debug(`ScormWrapper::getValue: ignoring request as 'finish' has been called`);
@@ -382,26 +382,26 @@ define([
         return;
       }
 
-      const _value = this.scorm.get(_property);
-      const _errorCode = this.scorm.debug.getCode();
+      const value = this.scorm.get(property);
+      const errorCode = this.scorm.debug.getCode();
 
-      if (_errorCode !== 0) {
-        if (_errorCode === 403) {
+      if (errorCode !== 0) {
+        if (errorCode === 403) {
           this.logger.warn('ScormWrapper::getValue: data model element not initialized');
         } else {
           this.handleError(new ScormError(CLIENT_COULD_NOT_GET_PROPERTY, {
-            property: _property,
-            info: this.scorm.debug.getInfo(_errorCode),
-            diagnosticInfo: this.scorm.debug.getDiagnosticInfo(_errorCode)
+            property: property,
+            info: this.scorm.debug.getInfo(errorCode),
+            diagnosticInfo: this.scorm.debug.getDiagnosticInfo(errorCode)
           }));
         }
       }
-      this.logger.debug(`ScormWrapper::getValue: returning ${_value}`);
-      return _value + '';
+      this.logger.debug(`ScormWrapper::getValue: returning ${value}`);
+      return value + '';
     }
 
-    setValue(_property, _value) {
-      this.logger.debug(`ScormWrapper::setValue: _property=${_property} _value=${_value}`);
+    setValue(property, value) {
+      this.logger.debug(`ScormWrapper::setValue: _property=${property} _value=${value}`);
 
       if (this.finishCalled) {
         this.logger.debug(`ScormWrapper::setValue: ignoring request as 'finish' has been called`);
@@ -413,21 +413,20 @@ define([
         return;
       }
 
-      const _success = this.scorm.set(_property, _value);
-      const _errorCode = this.scorm.debug.getCode();
-      let _errorMsg = '';
+      const success = this.scorm.set(property, value);
+      const errorCode = this.scorm.debug.getCode();
 
-      if (!_success) {
+      if (!success) {
       /**
        * Some LMSes have an annoying tendency to return false from a set call even when it actually worked fine.
        * So, we should throw an error _only_ if there was a valid error code...
        */
-        if (_errorCode !== 0) {
+        if (errorCode !== 0) {
           this.handleError(new ScormError(CLIENT_COULD_NOT_SET_PROPERTY, {
-            property: _property,
-            value: _value,
-            info: this.scorm.debug.getInfo(_errorCode),
-            diagnosticInfo: this.scorm.debug.getDiagnosticInfo(_errorCode)
+            property: property,
+            value: value,
+            info: this.scorm.debug.getInfo(errorCode),
+            diagnosticInfo: this.scorm.debug.getDiagnosticInfo(errorCode)
           }));
         } else {
           this.logger.warn(`ScormWrapper::setValue: LMS reported that the 'set' call failed but then said there was no error!`);
@@ -437,7 +436,7 @@ define([
 
       if (this.commitOnAnyChange) this.debouncedCommit();
 
-      return _success;
+      return success;
     }
 
     /**
@@ -445,8 +444,8 @@ define([
      * Note that the way this check is being performed means it wouldn't work for any element that is
      * 'write only', but so far we've not had a requirement to check for any optional elements that are.
      */
-    isSupported(_property) {
-      this.logger.debug(`ScormWrapper::isSupported: _property=${_property}`);
+    isSupported(property) {
+      this.logger.debug(`ScormWrapper::isSupported: _property=${property}`);
 
       if (this.finishCalled) {
         this.logger.debug(`ScormWrapper::isSupported: ignoring request as 'finish' has been called`);
@@ -458,7 +457,7 @@ define([
         return false;
       }
 
-      this.scorm.get(_property);
+      this.scorm.get(property);
 
       return (this.scorm.debug.getCode() === 401);
     }

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -390,8 +390,8 @@ define([
           this.logger.warn('ScormWrapper::getValue: data model element not initialized');
         } else {
           this.handleError(new ScormError(CLIENT_COULD_NOT_GET_PROPERTY, {
-            property: property,
-            code: errorCode,
+            property,
+            errorCode,
             errorInfo: this.scorm.debug.getInfo(errorCode),
             diagnosticInfo: this.scorm.debug.getDiagnosticInfo(errorCode)
           }));

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -739,7 +739,7 @@ define([
         i = parseInt(r);
 
         if (isNaN(i) || i < 10 || i > 35) {
-          self.handleError(new ScormError(CLIENT_INVALID_CHOICE_VALUE, { value }));
+          self.handleError(new ScormError(CLIENT_INVALID_CHOICE_VALUE));
         }
 
         return Number(i).toString(36); // 10 maps to 'a', 11 maps to 'b', ..., 35 maps to 'z'

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -508,7 +508,7 @@ define([
 
       this.logger.error(message);
 
-      if (!this.suppressErrors && (!this.logOutputWin || this.logOutputWin.closed) && confirm(`An error has occured:\n\n${message}\n\nPress 'OK' to view debug information to send to technical support.`)) {
+      if (!this.suppressErrors && (!this.logOutputWin || this.logOutputWin.closed) && confirm(`${messages.title}:\n\n${message}\n\n${messages.pressOk}`)) {
         this.showDebugWindow();
       }
 

--- a/properties.schema
+++ b/properties.schema
@@ -14,7 +14,7 @@
             "_spoor": {
               "type": "object",
               "required": false,
-              "legend": "Spoor",
+              "legend": "Spoor (SCORM)",
               "properties": {
                 "_isEnabled": {
                   "type": "boolean",

--- a/properties.schema
+++ b/properties.schema
@@ -244,7 +244,27 @@
           }
         },
         "course": {
-          "type":"object"
+          "type":"object",
+          "properties": {
+            "_spoor": {
+              "type": "object",
+              "required": false,
+              "legend": "Spoor (SCORM)",
+              "properties": {
+                "_messages": {
+                  "type": "object",
+                  "default": {},
+                  "title": "Error messages",
+                  "inputType": {
+                    "type": "CodeEditor",
+                    "mode": "json"
+                  },
+                  "validators": [],
+                  "help": "Optional object that can be used to amend/translate the error messages shown by the spoor extension"
+                }
+              }
+            }
+          }
         },
         "contentobject": {
           "type":"object"


### PR DESCRIPTION
* fixes https://github.com/adaptlearning/adapt_framework/issues/2945
* improve the display/wording of the error messages
* allow the entirety of the SCORM error popup to be amended/translated 
* allow the error messages to be amended via the AAT (similar to how the 'player options' are set for the media component')
* add '(SCORM)' to the spoor extension's label in course configuration to make it clearer what it's for!
* trim very long (>80 chars) error message values as these screw up the window.confirm display in Firefox
* ensure empty values (e.g. when bookmarking to menu) are displayed as `''` in error messages
* remove the `trim` function, it was only needed for IE8

