### PR TITLE
reverse logic of return statement in isSupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ These error messages can also be amended via the Adapt Authoring Tool - but must
 Currently (officially) only supports SCORM 1.2  
 
 ----------------------------
-**Version number:**  3.6.0   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
+**Version number:**  3.6.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  
 **Framework versions:** 5.5+  
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-spoor/graphs/contributors)  
 **Accessibility support:** n/a  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "framework": ">=5.5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -462,7 +462,7 @@ define([
 
       this.scorm.get(property);
 
-      return (this.scorm.debug.getCode() === 401);
+      return (this.scorm.debug.getCode() !== 401); // 401 is the 'not implemented' error code
     }
 
     initTimedCommit() {


### PR DESCRIPTION
so that it returns `false` if the error code is 401 and `true` if it's not

fixes https://github.com/adaptlearning/adapt_framework/issues/2991