### PR TITLE
issue/3138 printCompletionInformation shouldStoreResponses awareness

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -167,7 +167,10 @@ define([
       const max = Math.max(...data.map(item => item[0][0]));
       const completionString = data.reduce((markers, item) => {
         const trackingId = item[0][0];
-        const mark = item[2][1][0] ? '1' : '0';
+        const isComplete = this._shouldStoreResponses ?
+          item[2][1][0] :
+          item[1][0];
+        const mark = isComplete ? '1' : '0';
         markers[trackingId] = (markers[trackingId] === '-' || markers[trackingId] === '1') ?
           mark :
           '0';

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -165,9 +165,10 @@ define([
       }
       const data = SCORMSuspendData.deserialize(suspendData.q);
       const max = Math.max(...data.map(item => item[0][0]));
+      const shouldStoreResponses = (data[0].length === 3);
       const completionString = data.reduce((markers, item) => {
         const trackingId = item[0][0];
-        const isComplete = this._shouldStoreResponses ?
+        const isComplete = shouldStoreResponses ?
           item[2][1][0] :
           item[1][0];
         const mark = isComplete ? '1' : '0';


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/3138

### Fixed
* Made the `printCompletionInformation` function aware of the location of `isComplete` when `shouldStoreResponses` is `false` in the config.json