### PR TITLE
issue/1448 Don't report onAssessmentFailed until attempts are used

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -233,6 +233,7 @@ export default class StatefulSession extends Backbone.Controller {
         break;
       }
       case COMPLETION_STATE.FAILED: {
+        if (completionData.assessment?.canRetry === true) return;
         if (!config?._reporting?._onAssessmentFailure) {
           Adapt.log.warn(`No value defined for '_onAssessmentFailure', so defaulting to '${completionStatus}'`);
         } else {


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/1448
### Fixed
* Only report `_onAssessmentFailed` status when no more attempts are possible



Requires https://github.com/adaptlearning/adapt-contrib-assessment/pull/154