### PR TITLE
issue/232 Added offlineStorage.clear

### DIFF
--- a/js/adapt-offlineStorage-scorm.js
+++ b/js/adapt-offlineStorage-scorm.js
@@ -162,6 +162,13 @@ export default class OfflineStorageScorm extends Backbone.Controller {
     return (this.suspendDataRestored) ? this.scorm.setSuspendData(dataAsString) : false;
   }
 
+  clear() {
+    this.temporaryStore = {};
+    this.suspendDataStore = {};
+    const dataAsString = JSON.stringify(this.suspendDataStore);
+    this.scorm.setSuspendData(dataAsString);
+  }
+
   getCustomStates() {
     const isSuspendDataStoreEmpty = _.isEmpty(this.suspendDataStore);
     if (!isSuspendDataStoreEmpty && this.suspendDataRestored) {


### PR DESCRIPTION
fixes #232 
part of https://github.com/adaptlearning/adapt-contrib-core/pull/111

### Added
* `offlineStorage.clear()` backend

### Fixed
* Event attachment/detachment and function binding