### PR TITLE
Improve use of scorm_test_harness.html (fixes #247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ Determines the 'exit state' (`cmi.core.exit` in SCORM 1.2, `cmi.exit` in SCORM 2
 ##### \_exitStateIfComplete (string):
 Determines the 'exit state' (`cmi.core.exit` in SCORM 1.2, `cmi.exit` in SCORM 2004) to set when the course has been completed. The default behaviour will cause the exit state to be set to an empty string for SCORM 1.2 courses, or `"normal"` for SCORM 2004 courses. The default behaviour should be left in place unless you are confident you know what you are doing! Note: if you are using SCORM 2004, you can set this to `"suspend"` to prevent the LMS from clearing all progress tracking when a previously-completed course is re-launched by the learner.
 
+#### \_showCookieLmsResetButton (boolean):
+Determines whether a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only). The default is `false`.
+
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Notes

--- a/example.json
+++ b/example.json
@@ -27,7 +27,8 @@
             "_commitOnVisibilityChangeHidden": true,
             "_exitStateIfIncomplete": "auto",
             "_exitStateIfComplete": "auto"
-        }
+        },
+        "_showCookieLmsResetButton": false
     }
 
     // to be added to course/en/course.json (note: you only need to add the ones you want to change/translate)

--- a/properties.schema
+++ b/properties.schema
@@ -238,6 +238,15 @@
                       "help": "What exit status to use if the course is complete."
                     }
                   }
+                },
+                "_showCookieLmsResetButton": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "title": "Show reset button (scorm_test_harness.html only)",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "If enabled, a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only)."
                 }
               }
             }

--- a/required/offline_API_wrapper.js
+++ b/required/offline_API_wrapper.js
@@ -43,12 +43,14 @@ var GenericAPI = {
 
   createResetButton: function() {
     $('body').append($('<style id="spoor-clear-button">.spoor-reset-button { position:fixed; right:0px; bottom:0px; } </style>'));
-    var $button = $('<button class="spoor-reset-button">Reset</button>');
+    var $button = $('<button class="spoor-reset-button btn-text">Reset</button>');
     $('body').append($button);
-    $button.on('click', function() {
-      this.reset();
-      alert('SCORM tracking cookie has been deleted!');
-      window.location.reload();
+    $button.on('click', function(e) {
+      if (!e.shiftKey) {
+        this.reset();
+        alert('SCORM tracking cookie has been deleted! Tip: shift-click reset to preserve cookie.');
+      }
+      window.location = window.location.pathname;
     }.bind(this));
   },
 
@@ -72,7 +74,7 @@ var GenericAPI = {
 window.API = {
 
   LMSInitialize: function() {
-    // if (window.ISCOOKIELMS !== false) this.createResetButton();
+    if (window.ISCOOKIELMS !== false) this.createResetButton();
     if (!this.fetch()) {
       this.data['cmi.core.lesson_status'] = 'not attempted';
       this.data['cmi.suspend_data'] = '';
@@ -122,7 +124,7 @@ window.API = {
 window.API_1484_11 = {
 
   Initialize: function() {
-    // if (window.ISCOOKIELMS !== false) this.createResetButton();
+    if (window.ISCOOKIELMS !== false) this.createResetButton();
     if (!this.fetch()) {
       this.data['cmi.completion_status'] = 'not attempted';
       this.data['cmi.suspend_data'] = '';

--- a/required/offline_API_wrapper.js
+++ b/required/offline_API_wrapper.js
@@ -74,7 +74,11 @@ var GenericAPI = {
 window.API = {
 
   LMSInitialize: function() {
-    if (window.ISCOOKIELMS !== false) this.createResetButton();
+    const Adapt = require('core/js/adapt');
+    
+    if (window.ISCOOKIELMS !== false && Adapt?.config?.get('_spoor')?._showCookieLmsResetButton) {
+      this.createResetButton();
+    }
     if (!this.fetch()) {
       this.data['cmi.core.lesson_status'] = 'not attempted';
       this.data['cmi.suspend_data'] = '';
@@ -124,7 +128,11 @@ window.API = {
 window.API_1484_11 = {
 
   Initialize: function() {
-    if (window.ISCOOKIELMS !== false) this.createResetButton();
+    const Adapt = require('core/js/adapt');
+
+    if (window.ISCOOKIELMS !== false && Adapt?.config?.get('_spoor')?._showCookieLmsResetButton) {
+      this.createResetButton();
+    }
     if (!this.fetch()) {
       this.data['cmi.completion_status'] = 'not attempted';
       this.data['cmi.suspend_data'] = '';

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -169,6 +169,15 @@
                   "_backboneForms": "Select"
                 }
               }
+            },
+            "_showCookieLmsResetButton": {
+              "type": "boolean",
+              "required": false,
+              "default": false,
+              "title": "Show reset button (scorm_test_harness.html only)",
+              "inputType": "Checkbox",
+              "validators": [],
+              "help": "If enabled, a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only)."
             }
           }
         }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -172,12 +172,9 @@
             },
             "_showCookieLmsResetButton": {
               "type": "boolean",
-              "required": false,
               "default": false,
               "title": "Show reset button (scorm_test_harness.html only)",
-              "inputType": "Checkbox",
-              "validators": [],
-              "help": "If enabled, a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only)."
+              "description": "If enabled, a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only)."
             }
           }
         }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -172,9 +172,9 @@
             },
             "_showCookieLmsResetButton": {
               "type": "boolean",
-              "default": false,
               "title": "Show reset button (scorm_test_harness.html only)",
-              "description": "If enabled, a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only)."
+              "description": "If enabled, a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only).",
+              "default": false
             }
           }
         }


### PR DESCRIPTION
#247

### Update

1. make the reset button available so that we may clear tracking data easily
2. allow shift-clicking the reset button to relaunch but preserve tracking data
3. when reset is clicked simulate the user closing and relaunching the course (so no hash/query on the URL)
4. style the reset button in a familiar manner



