### PR TITLE
Fix: escaped double quotes in _setCompletedWhenFailed help msg (fixes #254)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -244,7 +244,7 @@
                       "title": "Completed when failed",
                       "inputType": "Checkbox",
                       "validators": [],
-                      "help": "If enabled, `cmi.completion_status` will be set to "completed" if the assessment is "failed". Only valid for SCORM 2004, where the logic for completion and success is separate."
+                      "help": "If enabled, `cmi.completion_status` will be set to \"completed\" if the assessment is \"failed\". Only valid for SCORM 2004, where the logic for completion and success is separate."
                     }
                   }
                 },


### PR DESCRIPTION
Fixes: #254 

### Fix
* Escaped quotation marks in the help section of _setCompletedWhenFailed
