### PR TITLE
New: Loss of Connection Feature (fixes: #268) - WIP

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -82,6 +82,9 @@ export default class StatefulSession extends Backbone.Controller {
     if (_.isBoolean(settings._setCompletedWhenFailed)) {
       this.scorm.setCompletedWhenFailed = settings._setCompletedWhenFailed;
     }
+    if (settings._connectionTest) {
+      Object.assign(this.scorm.connectionTest, settings._connectionTest);
+    }
     this.scorm.initialize();
   }
 

--- a/js/scorm/connection.js
+++ b/js/scorm/connection.js
@@ -1,0 +1,84 @@
+import Adapt from 'core/js/adapt';
+
+export default class Connection {
+
+  constructor({
+    _isEnabled = false,
+    _silentRetryLimit = 2,
+    _silentRetryDelay = 2000
+  } = {}, ScormWrapper) {
+    this._isEnabled = _isEnabled;
+    this._isInProgress = false;
+    this._isSilentDisconnection = false;
+    this._isDisconnected = false;
+    this._silentRetryLimit = _silentRetryLimit;
+    this._silentRetryDelay = _silentRetryDelay;
+    this._silentRetryTimeout = null;
+    this._silentRetryCount = 0;
+    this.scorm = ScormWrapper.getInstance();
+  }
+
+  test() {
+    if (!this._isEnabled || this._isInProgress) return;
+
+    this._isInProgress = true;
+
+    // @todo: replace with fetch and polyfill for IE11?
+    const xhr = new XMLHttpRequest();
+
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === XMLHttpRequest.DONE) {
+        if (xhr.status === 200) {
+          this.onConnectionSuccess();
+        } else {
+          this.onConnectionError();
+        }
+      }
+    };
+
+    xhr.open('GET', 'connection.json?nocache=' + Date.now());
+    // xhr.setRequestHeader("Accept", "application/json");
+    xhr.send();
+  }
+
+  reset() {
+    this._silentRetryCount = 0;
+    this._isSilentDisconnection = false;
+
+    if (this._silentRetryTimeout !== null) {
+      window.clearTimeout(this._silentRetryTimeout);
+      this._silentRetryTimeout = null;
+    }
+  }
+
+  onConnectionSuccess() {
+    if (this._isDisconnected) {
+      this.scorm.getInstance().commit();
+
+      if (!this._isSilentDisconnection) Adapt.trigger('tracking:connectionSuccess');
+    }
+
+    this._isInProgress = false;
+    this._isDisconnected = false;
+
+    this.reset();
+  }
+
+  onConnectionError() {
+    if (!this._isEnabled) return;
+
+    this._isInProgress = false;
+    this._isDisconnected = true;
+
+    if (this._silentRetryCount < this._silentRetryLimit) {
+      this._isSilentDisconnection = true;
+      this._silentRetryCount++;
+      this._silentRetryTimeout = window.setTimeout(this.test.bind(this), this._silentRetryDelay);
+    } else {
+      this.reset();
+
+      Adapt.trigger('tracking:connectionError', this.test.bind(this));
+    }
+  }
+
+}

--- a/required/connection.json
+++ b/required/connection.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### New
Solution for #268 
Possible solution for #245 
During a learner’s progression through a course, Adapt will be testing that connectivity is being maintained with the LMS. At the point a connection with either the LMS results in a failure, a notification pop-up will appear to the learner warning them of an error occurring and that future progression data isn’t being saved.

- The learner will be allowed to retry establishing their connection or close the course. 
- Selecting the Retry button will cause Adapt to attempt sending and retrieving a small data file to and from the LMS’s server.
- If unsuccessful, another notification will appear allowing the user to retry or close the module.
- If unsuccessful a 2nd time, a final notification will appear informing the learner they must close and re-launch the course.
- If successful, a new notification pop-up will appear informing the learner that their progress is being saved again.
- Selecting the Close will close the course and learners will return to the LMS.
- An additional configurable option will be provided if learners would like to continue progressing through the content at their own risk.
- All SCORM progress is being saved up until the point at which the loss of connection occurred.

[//]: # (List appropriate steps for testing if needed)
### Testing
1. More to follow

[//]: # (Mention any other dependencies)
### Work in Progress
While the connection error handling is in place, I still need to add in the UI for the notify pop-ups as well as configurable JSON fields to assist in on-screen messaging.

