### PR TITLE
New: network connection test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This extension provides course tracking functionality (hence the name [spoor](ht
 **Spoor** makes use of the excellent [pipwerks SCORM API Wrapper](https://github.com/pipwerks/scorm-api-wrapper/).
 
 [Visit the **Spoor** wiki](https://github.com/adaptlearning/adapt-contrib-spoor/wiki) for more information about its functionality and for explanations of key properties.
- 
+
 ## Installation
 
 As one of Adapt's *[core extensions](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#extensions),* **Spoor** is included with the [installation of the Adapt framework](https://github.com/adaptlearning/adapt_framework/wiki/Manual-installation-of-the-Adapt-framework#installation) and the [installation of the Adapt authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-Adapt-Origin).
@@ -130,6 +130,17 @@ Determines the 'exit state' (`cmi.core.exit` in SCORM 1.2, `cmi.exit` in SCORM 2
 
 ##### \_setCompletedWhenFailed (boolean):
 Determines whether the `cmi.completion_status` is set to "completed" if the assessment is "failed". Only valid for SCORM 2004, where the logic for completion and success is separate. The default is `true`.
+
+##### \_connectionTest (object):
+The settings used to configure the connection test when committing data to the LMS. The LMS API usually returns true for each data transmission regardless of the ability to persist the data. Contains the following attributes:
+
+ * **\_isEnabled** (boolean): Determines whether the connection should be tested. The default is `true`.
+
+ * **\_testOnSetValue** (boolean): Determines whether the connection should be tested for each call to set data on the LMS. The default is `true`.
+
+   * **_silentRetryLimit** (number): The limit for silent retry attempts to establish a connection before raising an error. The default is `0`.
+
+   * **_silentRetryDelay** (number): The interval in milliseconds between silent connection retries. The default is `2000`.
 
 #### \_showCookieLmsResetButton (boolean):
 Determines whether a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only). The default is `false`.

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ The settings used to configure the connection test when committing data to the L
 
  * **\_testOnSetValue** (boolean): Determines whether the connection should be tested for each call to set data on the LMS. The default is `true`.
 
-   * **_silentRetryLimit** (number): The limit for silent retry attempts to establish a connection before raising an error. The default is `0`.
+   * **_silentRetryLimit** (number): The limit for silent retry attempts to establish a connection before raising an error. The default is `2`.
 
-   * **_silentRetryDelay** (number): The interval in milliseconds between silent connection retries. The default is `2000`.
+   * **_silentRetryDelay** (number): The interval in milliseconds between silent connection retries. The default is `1000`.
 
 #### \_showCookieLmsResetButton (boolean):
 Determines whether a reset button will be available to relaunch the course and optionally clear tracking data (scorm_test_harness.html only). The default is `false`.

--- a/example.json
+++ b/example.json
@@ -27,7 +27,13 @@
             "_commitOnVisibilityChangeHidden": true,
             "_exitStateIfIncomplete": "auto",
             "_exitStateIfComplete": "auto",
-            "_setCompletedWhenFailed": true
+            "_setCompletedWhenFailed": true,
+            "_connectionTest": {
+              "_isEnabled": true,
+              "_testOnSetValue": true,
+              "_silentRetryLimit": 0,
+              "_silentRetryDelay": 2000
+            }
         },
         "_showCookieLmsResetButton": false,
         "_shouldPersistCookieLMSData": true

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -51,40 +51,7 @@ export default class StatefulSession extends Backbone.Controller {
       this.scorm.initialize();
       return;
     }
-    if (settings._showDebugWindow) {
-      this.scorm.showDebugWindow();
-    }
-    this.scorm.setVersion(settings._scormVersion || '1.2');
-    if (_.isBoolean(settings._suppressErrors)) {
-      this.scorm.suppressErrors = settings._suppressErrors;
-    }
-    if (_.isBoolean(settings._commitOnStatusChange)) {
-      this.scorm.commitOnStatusChange = settings._commitOnStatusChange;
-    }
-    if (_.isBoolean(settings._commitOnAnyChange)) {
-      this.scorm.commitOnAnyChange = settings._commitOnAnyChange;
-    }
-    if (_.isFinite(settings._timedCommitFrequency)) {
-      this.scorm.timedCommitFrequency = settings._timedCommitFrequency;
-    }
-    if (_.isFinite(settings._maxCommitRetries)) {
-      this.scorm.maxCommitRetries = settings._maxCommitRetries;
-    }
-    if (_.isFinite(settings._commitRetryDelay)) {
-      this.scorm.commitRetryDelay = settings._commitRetryDelay;
-    }
-    if ('_exitStateIfIncomplete' in settings) {
-      this.scorm.exitStateIfIncomplete = settings._exitStateIfIncomplete;
-    }
-    if ('_exitStateIfComplete' in settings) {
-      this.scorm.exitStateIfComplete = settings._exitStateIfComplete;
-    }
-    if (_.isBoolean(settings._setCompletedWhenFailed)) {
-      this.scorm.setCompletedWhenFailed = settings._setCompletedWhenFailed;
-    }
-    const connectionTest = settings._connectionTest;
-    if (connectionTest) Object.assign(this.scorm.connectionTest, connectionTest);
-    this.scorm.initialize();
+    this.scorm.initialize(settings);
   }
 
   restoreSession() {

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -82,6 +82,8 @@ export default class StatefulSession extends Backbone.Controller {
     if (_.isBoolean(settings._setCompletedWhenFailed)) {
       this.scorm.setCompletedWhenFailed = settings._setCompletedWhenFailed;
     }
+    const connectionTest = settings._connectionTest;
+    if (connectionTest) Object.assign(this.scorm.connectionTest, connectionTest);
     this.scorm.initialize();
   }
 

--- a/js/scorm/Connection.js
+++ b/js/scorm/Connection.js
@@ -3,9 +3,9 @@ import Adapt from 'core/js/adapt';
 export default class Connection {
 
   constructor({
-    _isEnabled = false,
-    _silentRetryLimit = 0,
-    _silentRetryDelay = 2000
+    _isEnabled = true,
+    _silentRetryLimit = 2,
+    _silentRetryDelay = 1000
   } = {}, ScormWrapper) {
     this._isEnabled = _isEnabled;
     this._isInProgress = false;

--- a/js/scorm/Connection.js
+++ b/js/scorm/Connection.js
@@ -5,8 +5,10 @@ export default class Connection {
   constructor({
     _isEnabled = true,
     _silentRetryLimit = 2,
-    _silentRetryDelay = 1000
+    _silentRetryDelay = 1000,
+    _testOnSetValue = true
   } = {}, ScormWrapper) {
+    this.test = this.test.bind(this);
     this._isEnabled = _isEnabled;
     this._isInProgress = false;
     this._isSilentDisconnection = false;
@@ -15,6 +17,7 @@ export default class Connection {
     this._silentRetryDelay = _silentRetryDelay;
     this._silentRetryTimeout = null;
     this._silentRetryCount = 0;
+    this._testOnSetValue = _testOnSetValue;
     this._scorm = ScormWrapper;
   }
 
@@ -26,6 +29,11 @@ export default class Connection {
       if (response?.ok) return this.onConnectionSuccess();
     } catch (err) {}
     this.onConnectionError();
+  }
+
+  async testOnSetValue() {
+    if (!this._isEnabled || !this._testOnSetValue) return;
+    return this.test();
   }
 
   reset() {
@@ -61,11 +69,11 @@ export default class Connection {
     if (this._silentRetryCount < this._silentRetryLimit) {
       this._isSilentDisconnection = true;
       this._silentRetryCount++;
-      this._silentRetryTimeout = window.setTimeout(this.test.bind(this), this._silentRetryDelay);
+      this._silentRetryTimeout = window.setTimeout(this.test, this._silentRetryDelay);
       return;
     }
     this.reset();
-    Adapt.trigger('tracking:connectionError', this.test.bind(this));
+    this._scorm.handleConnectionError(this.test);
   }
 
 }

--- a/js/scorm/Connection.js
+++ b/js/scorm/Connection.js
@@ -1,0 +1,78 @@
+import Adapt from 'core/js/adapt';
+
+export default class Connection {
+
+  constructor({
+    _isEnabled = false,
+    _silentRetryLimit = 0,
+    _silentRetryDelay = 2000
+  } = {}, ScormWrapper) {
+    this._isEnabled = _isEnabled;
+    this._isInProgress = false;
+    this._isSilentDisconnection = false;
+    this._isDisconnected = false;
+    this._silentRetryLimit = _silentRetryLimit;
+    this._silentRetryDelay = _silentRetryDelay;
+    this._silentRetryTimeout = null;
+    this._silentRetryCount = 0;
+    this._scorm = ScormWrapper;
+  }
+
+  async test() {
+    if (!this._isEnabled || this._isInProgress) return;
+    this._isInProgress = true;
+
+    fetch(`connection.json?nocache=${Date.now()}`)
+    .then(response => {
+      (response?.ok) ? this.onConnectionSuccess() : this.onConnectionError();
+    })
+    .catch(error => {
+      this.onConnectionError();
+    });
+  }
+
+  reset() {
+    this._silentRetryCount = 0;
+    this._isSilentDisconnection = false;
+
+    if (this._silentRetryTimeout !== null) {
+      window.clearTimeout(this._silentRetryTimeout);
+      this._silentRetryTimeout = null;
+    }
+  }
+
+  stop() {
+    this.reset();
+    this._isEnabled = false;
+  }
+
+  /**
+   * @todo Remove need for commit?
+   */
+  onConnectionSuccess() {
+    if (this._isDisconnected) {
+      this._scorm.commit();
+      if (!this._isSilentDisconnection) Adapt.trigger('tracking:connectionSuccess');
+    }
+
+    this._isInProgress = false;
+    this._isDisconnected = false;
+    this.reset();
+  }
+
+  onConnectionError() {
+    if (!this._isEnabled) return;
+    this._isInProgress = false;
+    this._isDisconnected = true;
+
+    if (this._silentRetryCount < this._silentRetryLimit) {
+      this._isSilentDisconnection = true;
+      this._silentRetryCount++;
+      this._silentRetryTimeout = window.setTimeout(this.test.bind(this), this._silentRetryDelay);
+    } else {
+      this.reset();
+      Adapt.trigger('tracking:connectionError', this.test.bind(this));
+    }
+  }
+
+}

--- a/js/scorm/Connection.js
+++ b/js/scorm/Connection.js
@@ -21,9 +21,8 @@ export default class Connection {
   async test() {
     if (!this._isEnabled || this._isInProgress) return;
     this._isInProgress = true;
-
     try {
-      const response = await fetch(`connection.json?nocache=${Date.now()}`);
+      const response = await fetch(`connection.txt?nocache=${Date.now()}`);
       if (response?.ok) return this.onConnectionSuccess();
     } catch (err) {}
     this.onConnectionError();
@@ -32,7 +31,6 @@ export default class Connection {
   reset() {
     this._silentRetryCount = 0;
     this._isSilentDisconnection = false;
-
     if (this._silentRetryTimeout === null) return;
     window.clearTimeout(this._silentRetryTimeout);
     this._silentRetryTimeout = null;
@@ -51,7 +49,6 @@ export default class Connection {
       this._scorm.commit();
       if (!this._isSilentDisconnection) Adapt.trigger('tracking:connectionSuccess');
     }
-
     this._isInProgress = false;
     this._isDisconnected = false;
     this.reset();
@@ -61,7 +58,6 @@ export default class Connection {
     if (!this._isEnabled) return;
     this._isInProgress = false;
     this._isDisconnected = true;
-
     if (this._silentRetryCount < this._silentRetryLimit) {
       this._isSilentDisconnection = true;
       this._silentRetryCount++;

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -125,7 +125,11 @@ class ScormWrapper {
       return this.lmsConnected;
     }
 
-    if (this.connectionTest._isEnabled) this._connection = new Connection(this.connectionTest, ScormWrapper.getInstance());
+    if (this.connectionTest._isEnabled) {
+      Adapt.on('tracking:connectionError', () => this.handleConnectionError(false));
+      this._connection = new Connection(this.connectionTest, ScormWrapper.getInstance());
+    }
+
     this.startTime = new Date();
     this.initTimedCommit();
     return this.lmsConnected;
@@ -511,8 +515,8 @@ class ScormWrapper {
     _.defer(() => this.handleError(new ScormError(CLIENT_COULD_NOT_CONNECT)));
   }
 
-  handleConnectionError() {
-    Adapt.trigger('tracking:connectionError');
+  handleConnectionError(triggerError = true) {
+    if (triggerError) Adapt.trigger('tracking:connectionError');
     this.handleError(new ScormError(CLIENT_NOT_CONNECTED));
   }
 

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -84,14 +84,11 @@ class ScormWrapper {
     this.scorm.handleExitMode = false;
 
     this.suppressErrors = false;
-    this.debouncedCommit = _.debounce(this.commit.bind(this), 100);
+    this.commit = this.commit.bind(this);
+    this.doRetryCommit = this.doRetryCommit.bind(this);
+    this.debouncedCommit = _.debounce(this.commit, 100);
     if (window.__debug) this.showDebugWindow();
     this._connection = null;
-
-    this.connectionTest = {
-      _isEnabled: true,
-      _testOnSetValue: true
-    };
 
     if (!(window.API?.__offlineAPIWrapper && window?.API_1484_11?.__offlineAPIWrapper)) return;
     this.logger.error('Offline SCORM API is being used. No data will be reported to the LMS!');
@@ -116,7 +113,41 @@ class ScormWrapper {
     this.scorm.version = value;
   }
 
-  initialize() {
+  initialize(settings) {
+    if (settings) {
+      if (settings._showDebugWindow) {
+        this.showDebugWindow();
+      }
+      this.setVersion(settings._scormVersion || '1.2');
+      if (_.isBoolean(settings._suppressErrors)) {
+        this.suppressErrors = settings._suppressErrors;
+      }
+      if (_.isBoolean(settings._commitOnStatusChange)) {
+        this.commitOnStatusChange = settings._commitOnStatusChange;
+      }
+      if (_.isBoolean(settings._commitOnAnyChange)) {
+        this.commitOnAnyChange = settings._commitOnAnyChange;
+      }
+      if (_.isFinite(settings._timedCommitFrequency)) {
+        this.timedCommitFrequency = settings._timedCommitFrequency;
+      }
+      if (_.isFinite(settings._maxCommitRetries)) {
+        this.maxCommitRetries = settings._maxCommitRetries;
+      }
+      if (_.isFinite(settings._commitRetryDelay)) {
+        this.commitRetryDelay = settings._commitRetryDelay;
+      }
+      if ('_exitStateIfIncomplete' in settings) {
+        this.exitStateIfIncomplete = settings._exitStateIfIncomplete;
+      }
+      if ('_exitStateIfComplete' in settings) {
+        this.exitStateIfComplete = settings._exitStateIfComplete;
+      }
+      if (_.isBoolean(settings._setCompletedWhenFailed)) {
+        this.setCompletedWhenFailed = settings._setCompletedWhenFailed;
+      }
+    }
+
     this.logger.debug('ScormWrapper::initialize');
     this.lmsConnected = this.scorm.init();
 
@@ -125,9 +156,8 @@ class ScormWrapper {
       return this.lmsConnected;
     }
 
-    if (this.connectionTest._isEnabled) {
-      Adapt.on('tracking:connectionError', () => this.handleConnectionError(false));
-      this._connection = new Connection(this.connectionTest, ScormWrapper.getInstance());
+    if (settings?._connectionTest?._isEnabled !== false) {
+      this._connection = new Connection(settings._connectionTest, this);
     }
 
     this.startTime = new Date();
@@ -439,7 +469,7 @@ class ScormWrapper {
     const success = this.scorm.set(property, value);
     if (success) {
       // if success, test the connection as the API usually returns true regardless of the ability to persist the data
-      if (this._connection && this.connectionTest._testOnSetValue) this._connection.test();
+      this._connection?.testOnSetValue();
     } else {
       // Some LMSs have an annoying tendency to return false from a set call even when it actually worked fine.
       // So we should only throw an error if there was a valid error code...
@@ -488,7 +518,7 @@ class ScormWrapper {
 
     if (!this.commitOnAnyChange && this.timedCommitFrequency > 0) {
       const delay = this.timedCommitFrequency * (60 * 1000);
-      this.timedCommitIntervalID = window.setInterval(this.commit.bind(this), delay);
+      this.timedCommitIntervalID = window.setInterval(this.commit, delay);
     }
   }
 
@@ -497,7 +527,7 @@ class ScormWrapper {
 
     this.commitRetryPending = true;// stop anything else from calling commit until this is done
 
-    this.retryCommitTimeoutID = window.setTimeout(this.doRetryCommit.bind(this), this.commitRetryDelay);
+    this.retryCommitTimeoutID = window.setTimeout(this.doRetryCommit, this.commitRetryDelay);
   }
 
   doRetryCommit() {
@@ -515,8 +545,8 @@ class ScormWrapper {
     _.defer(() => this.handleError(new ScormError(CLIENT_COULD_NOT_CONNECT)));
   }
 
-  handleConnectionError(triggerError = true) {
-    if (triggerError) Adapt.trigger('tracking:connectionError');
+  handleConnectionError(callback = null) {
+    Adapt.trigger('tracking:connectionError', callback);
     this.handleError(new ScormError(CLIENT_NOT_CONNECTED));
   }
 

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -89,8 +89,8 @@ class ScormWrapper {
     this._connection = null;
 
     this.connectionTest = {
-      _isEnabled: false,
-      _testOnSetValue: false
+      _isEnabled: true,
+      _testOnSetValue: true
     };
 
     if (!(window.API?.__offlineAPIWrapper && window?.API_1484_11?.__offlineAPIWrapper)) return;

--- a/properties.schema
+++ b/properties.schema
@@ -258,6 +258,47 @@
                       "inputType": "Checkbox",
                       "validators": [],
                       "help": "If enabled, `cmi.completion_status` will be set to \"completed\" if the assessment is \"failed\". Only valid for SCORM 2004, where the logic for completion and success is separate."
+                    },
+                    "_connectionTest": {
+                      "type": "object",
+                      "required": true,
+                      "title": "Connection Test",
+                      "properties": {
+                        "_isEnabled": {
+                          "type": "boolean",
+                          "default": true,
+                          "title": "Is Enabled",
+                          "inputType": "Checkbox",
+                          "validators": [],
+                          "help": "Determines whether the connection should be tested."
+                        },
+                        "_testOnSetValue": {
+                          "type": "boolean",
+                          "default": true,
+                          "title": "Test on set value",
+                          "inputType": "Checkbox",
+                          "validators": [],
+                          "help": "Determines whether the connection should be tested for each call to set data on the LMS."
+                        },
+                        "_timedCommitFrequency": {
+                          "type": "number",
+                          "required": false,
+                          "default": "0",
+                          "title": "Timed commit frequency",
+                          "inputType": "Number",
+                          "validators": ["number"],
+                          "help": "The limit for silent retry attempts to establish a connection before raising an error."
+                        },
+                        "_silentRetryDelay": {
+                          "type": "number",
+                          "required": false,
+                          "default": "2000",
+                          "title": "Silent Retry Delay",
+                          "inputType": "Number",
+                          "validators": ["number"],
+                          "help": "The interval in milliseconds between silent connection retries."
+                        }
+                      }
                     }
                   }
                 },

--- a/properties.schema
+++ b/properties.schema
@@ -280,11 +280,11 @@
                           "validators": [],
                           "help": "Determines whether the connection should be tested for each call to set data on the LMS."
                         },
-                        "_timedCommitFrequency": {
+                        "_silentRetryLimit": {
                           "type": "number",
                           "required": false,
-                          "default": "0",
-                          "title": "Timed commit frequency",
+                          "default": "2",
+                          "title": "Silent Retry Limit",
                           "inputType": "Number",
                           "validators": ["number"],
                           "help": "The limit for silent retry attempts to establish a connection before raising an error."
@@ -292,7 +292,7 @@
                         "_silentRetryDelay": {
                           "type": "number",
                           "required": false,
-                          "default": "2000",
+                          "default": "1000",
                           "title": "Silent Retry Delay",
                           "inputType": "Number",
                           "validators": ["number"],

--- a/required/connection.json
+++ b/required/connection.json
@@ -1,3 +1,0 @@
-{
-  "success": true
-}

--- a/required/connection.json
+++ b/required/connection.json
@@ -1,0 +1,3 @@
+{
+  "success": true
+}

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -202,17 +202,17 @@
                       "description": "Determines whether the connection should be tested for each call to set data on the LMS.",
                       "default": true
                     },
-                    "_timedCommitFrequency": {
+                    "_silentRetryLimit": {
                       "type": "number",
-                      "title": "Timed commit frequency",
+                      "title": "Silent Retry Limit",
                       "description": "The limit for silent retry attempts to establish a connection before raising an error.",
-                      "default": 0
+                      "default": 2
                     },
-                    "_commitOnAnyChange": {
+                    "_silentRetryDelay": {
                       "type": "number",
                       "title": "Silent Retry Delay",
                       "description": "The interval in milliseconds between silent connection retries.",
-                      "default": 0
+                      "default": 1000
                     }
                   }
                 }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -184,6 +184,37 @@
                   "title": "Completed when failed",
                   "description": "If enabled, `cmi.completion_status` will be set to \"completed\" if the assessment is \"failed\". Only valid for SCORM 2004, where the logic for completion and success is separate.",
                   "default": true
+                },
+                "_connectionTest": {
+                  "type": "object",
+                  "title": "Connection Test",
+                  "default": {},
+                  "properties": {
+                    "_isEnabled": {
+                      "type": "boolean",
+                      "title": "Enable connection test",
+                      "description": "Determines whether the connection should be tested.",
+                      "default": true
+                    },
+                    "_testOnSetValue": {
+                      "type": "boolean",
+                      "title": "Test on set value",
+                      "description": "Determines whether the connection should be tested for each call to set data on the LMS.",
+                      "default": true
+                    },
+                    "_timedCommitFrequency": {
+                      "type": "number",
+                      "title": "Timed commit frequency",
+                      "description": "The limit for silent retry attempts to establish a connection before raising an error.",
+                      "default": 0
+                    },
+                    "_commitOnAnyChange": {
+                      "type": "number",
+                      "title": "Silent Retry Delay",
+                      "description": "The interval in milliseconds between silent connection retries.",
+                      "default": 0
+                    }
+                  }
                 }
               }
             },


### PR DESCRIPTION
Fixes #268 

### New
* Added feature to test the network connection when transferring data to the LMS API.
* Raises an error if the connection is lost.

Further error handling can be utlised with [adapt-contrib-trackingErrors](https://github.com/adaptlearning/adapt-contrib-trackingErrors).




