### PR TITLE
Fix: Correct printCompletionInformation string creation

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -186,7 +186,7 @@ export default class StatefulSession extends Backbone.Controller {
         mark :
         '0';
       return markers;
-    }, (new Array(max + 1).join('-').split(''))).join('');
+    }, new Array(max + 1).fill('-')).join('');
     logging.info(`course._isComplete: ${courseComplete}, course._isAssessmentPassed: ${assessmentPassed}, ${this._trackingIdType} completion: ${completionString}`);
   }
 


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-spoor/issues/271

### Fix
* Correct printCompletionInformation string creation, off by one error in array length
