### PR TITLE
Slight refactor

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -51,40 +51,7 @@ export default class StatefulSession extends Backbone.Controller {
       this.scorm.initialize();
       return;
     }
-    if (settings._showDebugWindow) {
-      this.scorm.showDebugWindow();
-    }
-    this.scorm.setVersion(settings._scormVersion || '1.2');
-    if (_.isBoolean(settings._suppressErrors)) {
-      this.scorm.suppressErrors = settings._suppressErrors;
-    }
-    if (_.isBoolean(settings._commitOnStatusChange)) {
-      this.scorm.commitOnStatusChange = settings._commitOnStatusChange;
-    }
-    if (_.isBoolean(settings._commitOnAnyChange)) {
-      this.scorm.commitOnAnyChange = settings._commitOnAnyChange;
-    }
-    if (_.isFinite(settings._timedCommitFrequency)) {
-      this.scorm.timedCommitFrequency = settings._timedCommitFrequency;
-    }
-    if (_.isFinite(settings._maxCommitRetries)) {
-      this.scorm.maxCommitRetries = settings._maxCommitRetries;
-    }
-    if (_.isFinite(settings._commitRetryDelay)) {
-      this.scorm.commitRetryDelay = settings._commitRetryDelay;
-    }
-    if ('_exitStateIfIncomplete' in settings) {
-      this.scorm.exitStateIfIncomplete = settings._exitStateIfIncomplete;
-    }
-    if ('_exitStateIfComplete' in settings) {
-      this.scorm.exitStateIfComplete = settings._exitStateIfComplete;
-    }
-    if (_.isBoolean(settings._setCompletedWhenFailed)) {
-      this.scorm.setCompletedWhenFailed = settings._setCompletedWhenFailed;
-    }
-    const connectionTest = settings._connectionTest;
-    if (connectionTest) Object.assign(this.scorm.connectionTest, connectionTest);
-    this.scorm.initialize();
+    this.scorm.initialize(settings);
   }
 
   restoreSession() {

--- a/js/scorm/Connection.js
+++ b/js/scorm/Connection.js
@@ -5,8 +5,10 @@ export default class Connection {
   constructor({
     _isEnabled = true,
     _silentRetryLimit = 2,
-    _silentRetryDelay = 1000
+    _silentRetryDelay = 1000,
+    _testOnSetValue = true
   } = {}, ScormWrapper) {
+    this.test = this.test.bind(this);
     this._isEnabled = _isEnabled;
     this._isInProgress = false;
     this._isSilentDisconnection = false;
@@ -15,6 +17,7 @@ export default class Connection {
     this._silentRetryDelay = _silentRetryDelay;
     this._silentRetryTimeout = null;
     this._silentRetryCount = 0;
+    this._testOnSetValue = _testOnSetValue;
     this._scorm = ScormWrapper;
   }
 
@@ -26,6 +29,11 @@ export default class Connection {
       if (response?.ok) return this.onConnectionSuccess();
     } catch (err) {}
     this.onConnectionError();
+  }
+
+  async testOnSetValue() {
+    if (!this._isEnabled || !this._testOnSetValue) return;
+    return this.test();
   }
 
   reset() {
@@ -61,11 +69,11 @@ export default class Connection {
     if (this._silentRetryCount < this._silentRetryLimit) {
       this._isSilentDisconnection = true;
       this._silentRetryCount++;
-      this._silentRetryTimeout = window.setTimeout(this.test.bind(this), this._silentRetryDelay);
+      this._silentRetryTimeout = window.setTimeout(this.test, this._silentRetryDelay);
       return;
     }
     this.reset();
-    Adapt.trigger('tracking:connectionError', this.test.bind(this));
+    this._scorm.handleConnectionError(this.test);
   }
 
 }

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -469,7 +469,7 @@ class ScormWrapper {
     const success = this.scorm.set(property, value);
     if (success) {
       // if success, test the connection as the API usually returns true regardless of the ability to persist the data
-      this._connection?.testOnSetValue?.();
+      this._connection?.testOnSetValue();
     } else {
       // Some LMSs have an annoying tendency to return false from a set call even when it actually worked fine.
       // So we should only throw an error if there was a valid error code...


### PR DESCRIPTION
Sub pr for https://github.com/adaptlearning/adapt-contrib-spoor/pull/270

* Moved wrapper config setup into the wrapper, removing need for `connectionTest` config object
* Call `tracking:connectionError` from one location only, simplifying its relationship to other bits of code
* Removed repetitive `bind(this)` to singular versions



