### PR TITLE
Fix: Undefined settings error

### DIFF
--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -157,7 +157,7 @@ class ScormWrapper {
     }
 
     if (settings?._connectionTest?._isEnabled !== false) {
-      this._connection = new Connection(settings._connectionTest, this);
+      this._connection = new Connection(settings?._connectionTest, this);
     }
 
     this.startTime = new Date();


### PR DESCRIPTION
fixes #274 

### Fix
* Default, missing config error correction

Actual defaults come from class constructor:
https://github.com/adaptlearning/adapt-contrib-spoor/blob/4a727367fc7a4ac531033b190ef2228b59c415a5/js/scorm/Connection.js#L5-L10