### PR TITLE
New: Added _uniqueInteractionIds, testing support for cmi.interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Determines whether a reset button will be available to relaunch the course and o
 #### \_shouldPersistCookieLMSData (boolean):
 Determines whether to persist the cookie data over browser sessions (scorm_test_harness.html only). The default is `true`.
 
+#### \_uniqueInteractionIds (boolean):
+Determines whether `cmi.interactions.n.id` will be prepended with an index, making the id unique. Some LMSes require unique ids, this will inhibit the grouping of interactions by id on the server-side.
+
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Notes

--- a/example.json
+++ b/example.json
@@ -33,7 +33,8 @@
               "_testOnSetValue": true,
               "_silentRetryLimit": 0,
               "_silentRetryDelay": 2000
-            }
+            },
+            "_uniqueInteractionIds": false
         },
         "_showCookieLmsResetButton": false,
         "_shouldPersistCookieLMSData": true

--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -19,6 +19,7 @@ export default class StatefulSession extends Backbone.Controller {
     this._shouldStoreResponses = true;
     this._shouldStoreAttempts = false;
     this._shouldRecordInteractions = true;
+    this._uniqueInteractionIds = false;
     this.beginSession();
   }
 
@@ -51,6 +52,7 @@ export default class StatefulSession extends Backbone.Controller {
       this.scorm.initialize();
       return;
     }
+    this._uniqueInteractionIds = settings._uniqueInteractionIds || false;
     this.scorm.initialize(settings);
   }
 
@@ -177,7 +179,9 @@ export default class StatefulSession extends Backbone.Controller {
     // If responseType doesn't contain any data, assume that the question
     // component hasn't been set up for cmi.interaction tracking
     if (_.isEmpty(responseType)) return;
-    const id = `${this.scorm.getInteractionCount()}-${questionModel.get('_id')}`;
+    const id = this._uniqueInteractionIds
+      ? `${this.scorm.getInteractionCount()}-${questionModel.get('_id')}`
+      : questionModel.get('_id');
     const response = (questionModel.getResponse ? questionModel.getResponse() : questionView.getResponse());
     const result = (questionModel.isCorrect ? questionModel.isCorrect() : questionView.isCorrect());
     const latency = (questionModel.getLatency ? questionModel.getLatency() : questionView.getLatency());

--- a/js/scorm/cookieLMS.js
+++ b/js/scorm/cookieLMS.js
@@ -99,6 +99,13 @@ export function start () {
 
       this.data = Cookies.getJSON('_spoor');
 
+      if (!this.data) {
+        this.data = {};
+        Object.entries(defaults).forEach(([name, value]) => set(this.data, name, value));
+        this.store(true);
+        return false;
+      }
+
       const entries = Object.entries(this.data);
       const isUsingLegacyKeys = (entries[0][0].includes('.'));
       if (isUsingLegacyKeys) {
@@ -111,13 +118,6 @@ export function start () {
         Object.entries(entries).forEach(([name, value]) => set(reworked, name, value));
         this.data = reworked;
         this.store(true);
-      }
-
-      if (!this.data) {
-        this.data = {};
-        Object.entries(defaults).forEach(([name, value]) => set(this.data, name, value));
-        this.store(true);
-        return false;
       }
 
       return true;

--- a/js/scorm/cookieLMS.js
+++ b/js/scorm/cookieLMS.js
@@ -94,6 +94,7 @@ export function start () {
     initialize: function(defaults = {}) {
       if (!isStoringData) {
         this.data = {};
+        Object.entries(defaults).forEach(([path, value]) => set(this.data, path, value));
         return;
       }
 

--- a/js/scorm/cookieLMS.js
+++ b/js/scorm/cookieLMS.js
@@ -80,7 +80,7 @@ export function start () {
 
     __offlineAPIWrapper: true,
 
-    store: function(force) {
+    store(force) {
       if (!isStoringData) return;
 
       if (!force && Cookies.get('_spoor') === undefined) return;
@@ -91,7 +91,7 @@ export function start () {
       if (Cookies.get('_spoor').length !== JSON.stringify(this.data).length) postStorageWarning();
     },
 
-    initialize: function(defaults = {}) {
+    initialize(defaults = {}) {
       if (!isStoringData) {
         this.data = {};
         Object.entries(defaults).forEach(([path, value]) => set(this.data, path, value));
@@ -127,11 +127,11 @@ export function start () {
   };
 
   // SCORM 1.2 API
-  window.API = {
+  const SCORM1_2 = window.API = {
 
     ...GenericAPI,
 
-    LMSInitialize: function() {
+    LMSInitialize() {
       configure();
       this.initialize({
         'cmi.interactions': [],
@@ -143,11 +143,11 @@ export function start () {
       return 'true';
     },
 
-    LMSFinish: function() {
+    LMSFinish() {
       return 'true';
     },
 
-    LMSGetValue: function(path) {
+    LMSGetValue(path) {
       const value = get(this.data, path);
       const keys = path.split('.');
       const firstKey = keys[0];
@@ -160,7 +160,7 @@ export function start () {
       return value;
     },
 
-    LMSSetValue: function(path, value) {
+    LMSSetValue(path, value) {
       const keys = path.split('.');
       const firstKey = keys[0];
       const lastKey = keys[keys.length - 1];
@@ -173,19 +173,19 @@ export function start () {
       return 'true';
     },
 
-    LMSCommit: function() {
+    LMSCommit() {
       return 'true';
     },
 
-    LMSGetLastError: function() {
+    LMSGetLastError() {
       return 0;
     },
 
-    LMSGetErrorString: function() {
+    LMSGetErrorString() {
       return 'Fake error string.';
     },
 
-    LMSGetDiagnostic: function() {
+    LMSGetDiagnostic() {
       return 'Fake diagnostic information.';
     }
   };
@@ -195,7 +195,7 @@ export function start () {
 
     ...GenericAPI,
 
-    Initialize: function() {
+    Initialize() {
       configure();
       this.initialize({
         'cmi.interactions': [],
@@ -207,51 +207,13 @@ export function start () {
       return 'true';
     },
 
-    Terminate: function() {
-      return 'true';
-    },
-
-    GetValue: function(path) {
-      const value = get(this.data, path);
-      const keys = path.split('.');
-      const firstKey = keys[0];
-      const lastKey = keys[keys.length - 1];
-      if (firstKey === 'cmi' && lastKey === '_count') {
-        // Treat requests for cmi.*._count as an array length query
-        const arrayPath = keys.slice(0, -1).join('.');
-        return get(this.data, arrayPath)?.length ?? 0;
-      }
-      return value;
-    },
-
-    SetValue: function(path, value) {
-      const keys = path.split('.');
-      const firstKey = keys[0];
-      const lastKey = keys[keys.length - 1];
-      if (firstKey === 'cmi' && lastKey === '_count') {
-        // Fail silently
-        return 'true';
-      }
-      set(this.data, path, value);
-      this.store();
-      return 'true';
-    },
-
-    Commit: function() {
-      return 'true';
-    },
-
-    GetLastError: function() {
-      return 0;
-    },
-
-    GetErrorString: function() {
-      return 'Fake error string.';
-    },
-
-    GetDiagnostic: function() {
-      return 'Fake diagnostic information.';
-    }
+    Terminate: SCORM1_2.LMSFinish,
+    GetValue: SCORM1_2.LMSGetValue,
+    SetValue: SCORM1_2.LMSSetValue,
+    Commit: SCORM1_2.LMSCommit,
+    GetLastError: SCORM1_2.LMSGetLastError,
+    GetErrorString: SCORM1_2.LMSGetErrorString,
+    GetDiagnostic: SCORM1_2.LMSGetDiagnostic
 
   };
 }

--- a/js/scorm/cookieLMS.js
+++ b/js/scorm/cookieLMS.js
@@ -101,7 +101,7 @@ export function start () {
 
       if (!this.data) {
         this.data = {};
-        Object.entries(defaults).forEach(([name, value]) => set(this.data, name, value));
+        Object.entries(defaults).forEach(([path, value]) => set(this.data, path, value));
         this.store(true);
         return false;
       }
@@ -114,8 +114,8 @@ export function start () {
          * to: { cmi: { student_name: '' } }
          */
         const reworked = {};
-        Object.entries(defaults).forEach(([name, value]) => set(reworked, name, value));
-        Object.entries(entries).forEach(([name, value]) => set(reworked, name, value));
+        Object.entries(defaults).forEach(([path, value]) => set(reworked, path, value));
+        Object.entries(entries).forEach(([path, value]) => set(reworked, path, value));
         this.data = reworked;
         this.store(true);
       }
@@ -146,23 +146,28 @@ export function start () {
       return 'true';
     },
 
-    LMSGetValue: function(key) {
-      const value = get(this.data, key);
-      const parts = key.split('.');
-      if (parts[0] === 'cmi' && parts[parts.length - 1] === '_count') {
+    LMSGetValue: function(path) {
+      const value = get(this.data, path);
+      const keys = path.split('.');
+      const firstKey = keys[0];
+      const lastKey = keys[keys.length - 1];
+      if (firstKey === 'cmi' && lastKey === '_count') {
         // Treat requests for cmi.*._count as an array length query
-        return get(this.data, parts.slice(0, -1).join('.'))?.length ?? 0;
+        const arrayPath = keys.slice(0, -1).join('.');
+        return get(this.data, arrayPath)?.length ?? 0;
       }
       return value;
     },
 
-    LMSSetValue: function(key, value) {
-      const parts = key.split('.');
-      if (parts[0] === 'cmi' && parts[parts.length - 1] === '_count') {
+    LMSSetValue: function(path, value) {
+      const keys = path.split('.');
+      const firstKey = keys[0];
+      const lastKey = keys[keys.length - 1];
+      if (firstKey === 'cmi' && lastKey === '_count') {
         // Fail silently
         return 'true';
       }
-      set(this.data, key, value);
+      set(this.data, path, value);
       this.store();
       return 'true';
     },
@@ -205,22 +210,28 @@ export function start () {
       return 'true';
     },
 
-    GetValue: function(key) {
-      const parts = key.split('.');
-      if (parts[0] === 'cmi' && parts[parts.length - 1] === '_count') {
+    GetValue: function(path) {
+      const value = get(this.data, path);
+      const keys = path.split('.');
+      const firstKey = keys[0];
+      const lastKey = keys[keys.length - 1];
+      if (firstKey === 'cmi' && lastKey === '_count') {
         // Treat requests for cmi.*._count as an array length query
-        return get(this.data, parts.slice(0, -1).join('.'))?.length ?? 0;
+        const arrayPath = keys.slice(0, -1).join('.');
+        return get(this.data, arrayPath)?.length ?? 0;
       }
-      return get(this.data, key);
+      return value;
     },
 
-    SetValue: function(key, value) {
-      const parts = key.split('.');
-      if (parts[0] === 'cmi' && parts[parts.length - 1] === '_count') {
+    SetValue: function(path, value) {
+      const keys = path.split('.');
+      const firstKey = keys[0];
+      const lastKey = keys[keys.length - 1];
+      if (firstKey === 'cmi' && lastKey === '_count') {
         // Fail silently
         return 'true';
       }
-      set(this.data, key, value);
+      set(this.data, path, value);
       this.store();
       return 'true';
     },

--- a/js/scorm/cookieLMS.js
+++ b/js/scorm/cookieLMS.js
@@ -7,6 +7,12 @@ export const shouldStart = (Object.prototype.hasOwnProperty.call(window, 'ISCOOK
 /** Store the data in a cookie if window.ISCOOKIELMS is true, otherwise setup the API without storing data. */
 export const isStoringData = (window.ISCOOKIELMS === true);
 
+/**
+ * Store value nested inside object at given path
+ * @param {Object} object Root of hierarchy
+ * @param {string} path Period separated key names
+ * @param {*} value Value to store at final path
+ */
 export const set = (object, path, value) => {
   const keys = path.split('.');
   const initialKeys = keys.slice(0, -1);
@@ -17,6 +23,12 @@ export const set = (object, path, value) => {
   finalObject[lastKey] = value;
 };
 
+/**
+ * Fetch value nested inside object at given path
+ * @param {Object} object
+ * @param {string} path  Period separated key names
+ * @returns
+ */
 export const get = (object, path) => {
   const keys = path.split('.');
   return keys.reduce((object, key) => object?.[key], object);
@@ -138,6 +150,7 @@ export function start () {
       const value = get(this.data, key);
       const parts = key.split('.');
       if (parts[0] === 'cmi' && parts[parts.length - 1] === '_count') {
+        // Treat requests for cmi.*._count as an array length query
         return get(this.data, parts.slice(0, -1).join('.'))?.length ?? 0;
       }
       return value;
@@ -146,6 +159,7 @@ export function start () {
     LMSSetValue: function(key, value) {
       const parts = key.split('.');
       if (parts[0] === 'cmi' && parts[parts.length - 1] === '_count') {
+        // Fail silently
         return 'true';
       }
       set(this.data, key, value);
@@ -194,6 +208,7 @@ export function start () {
     GetValue: function(key) {
       const parts = key.split('.');
       if (parts[0] === 'cmi' && parts[parts.length - 1] === '_count') {
+        // Treat requests for cmi.*._count as an array length query
         return get(this.data, parts.slice(0, -1).join('.'))?.length ?? 0;
       }
       return get(this.data, key);
@@ -202,6 +217,7 @@ export function start () {
     SetValue: function(key, value) {
       const parts = key.split('.');
       if (parts[0] === 'cmi' && parts[parts.length - 1] === '_count') {
+        // Fail silently
         return 'true';
       }
       set(this.data, key, value);

--- a/properties.schema
+++ b/properties.schema
@@ -299,6 +299,15 @@
                           "help": "The interval in milliseconds between silent connection retries."
                         }
                       }
+                    },
+                    "_uniqueInteractionIds": {
+                      "type": "boolean",
+                      "required": false,
+                      "default": false,
+                      "title": "Unique Interaction Ids",
+                      "inputType": "Checkbox",
+                      "validators": [],
+                      "help": "If enabled, `cmi.interactions.n.id` will be prepended with an index, making the id unique. Some LMSes require unique ids, this will inhibit the grouping of interactions by id on the server-side."
                     }
                   }
                 },

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -215,6 +215,12 @@
                       "default": 1000
                     }
                   }
+                },
+                "_uniqueInteractionIds": {
+                  "type": "boolean",
+                  "title": "Unique Interaction Ids",
+                  "description": "If enabled, `cmi.interactions.n.id` will be prepended with an index, making the id unique. Some LMSes require unique ids, this will inhibit the grouping of interactions by id on the server-side.",
+                  "default": false
                 }
               }
             },


### PR DESCRIPTION
fixes #277 

### New
* `config.json:_spoor._advancedSettings._uniqueInteractionIds = false` to allow control over unique `cmi.interactions.n.id` entries
* Switched cookeLMS to store values in nested objects and arrays rather than as a hash of key value pairs (backward compatible), such that it's possible to properly test the `cmi.interactions` property. In the future `cmi.objectives`, `cmi.comments_from_learner` and `cmi.interactions.n.objectives.m` can be easily added to the `scorm_test_harness.html` cookie lms as a result

The cookie lms will look like this now:
![image](https://github.com/adaptlearning/adapt-contrib-spoor/assets/7974663/f953aef2-e224-4eaa-a48e-b010a095c9ee)

Instead of this:
![image](https://github.com/adaptlearning/adapt-contrib-spoor/assets/7974663/dd1a651e-2560-4520-9a92-6a2ee1d99b56)

[SCORM 2004 v4 Spec, RTE-4-5](https://github.com/adaptlearning/scorm_docs/blob/master/SCORM%202004/4th%20Edition/SCORM_2004_4ED_v1_1_RTE_20090814.pdf):
Only support for `cmi.interactions` has been added to the testing environment.
1. ![image](https://github.com/adaptlearning/adapt-contrib-spoor/assets/7974663/f4a1ecc1-b8d5-440c-8808-d970ba4e3bee)
2. ![image](https://github.com/adaptlearning/adapt-contrib-spoor/assets/7974663/2e0429d8-889a-417d-8edd-9c2426dab67e)

### Testing
Running from scorm_test_harness.html, in the console, `window.API.LMSGetValue('cmi.interactions._count')` should return `0` initially and then the number of interactions if any questions are answered.
