### PR TITLE
Fix: wrapper.js & adapt-contrib-spoor updated to work with Jest testing. (fixes #284)

### DIFF
--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -4,6 +4,7 @@ import StatefulSession from './adapt-stateful-session';
 import OfflineStorage from './adapt-offlineStorage-scorm';
 import offlineStorage from 'core/js/offlineStorage';
 import { shouldStart as shouldStartCookieLMS, start as startCookieLMS } from './scorm/cookieLMS';
+import { onKeyCombo } from './../libraries/jquery.keycombo';
 
 class Spoor extends Backbone.Controller {
 
@@ -27,12 +28,10 @@ class Spoor extends Backbone.Controller {
     // of the course data loads
     offlineStorage.get();
     offlineStorage.setReadyStatus();
+
     // setup debug window keyboard shortcut
-    require(['libraries/jquery.keycombo'], () => {
-      // listen for user holding 'd', 'e', 'v' keys together
-      $.onKeyCombo([68, 69, 86], () => {
-        Adapt.spoor.scorm.showDebugWindow();
-      });
+    $.onKeyCombo([68, 69, 86], () => {
+      Adapt.spoor.scorm.showDebugWindow();
     });
   }
 

--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -4,7 +4,7 @@ import StatefulSession from './adapt-stateful-session';
 import OfflineStorage from './adapt-offlineStorage-scorm';
 import offlineStorage from 'core/js/offlineStorage';
 import { shouldStart as shouldStartCookieLMS, start as startCookieLMS } from './scorm/cookieLMS';
-import { onKeyCombo } from './../libraries/jquery.keycombo';
+import './../libraries/jquery.keycombo';
 
 class Spoor extends Backbone.Controller {
 

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -584,6 +584,8 @@ class ScormWrapper {
       if (error.data.value === '') error.data.value = '\'\'';
     }
 
+    if (!Adapt.course) return;
+
     const config = Adapt.course.get('_spoor');
     const messages = Object.assign({}, ScormError.defaultMessages, config && config._messages);
     const message = Handlebars.compile(messages[error.name])(error.data);


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#284 

Linked to Jest testing (https://github.com/adaptlearning/adapt_framework/pull/3383)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Return early added to wrapper.js if Adapt.course does not exist
* jquery.keycombo changed from require to import


