### PR TITLE
Fix: Check LMS supports cmi.interactions._count (fixes #294)

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -204,6 +204,7 @@ export default class StatefulSession extends Backbone.Controller {
 
   onQuestionRecordInteraction(questionView) {
     if (!this._shouldRecordInteractions) return;
+    if (!this.scorm.isSupported('cmi.interactions._count')) return;
     // View functions are deprecated: getResponseType, getResponse, isCorrect, getLatency
     const questionModel = questionView.model;
     const responseType = (questionModel.getResponseType ? questionModel.getResponseType() : questionView.getResponseType());


### PR DESCRIPTION
fixes #294 

### Fix
Add a check that the LMS supports cms.interactions._count to prevent error message appearing to user

### Testing
1. Create a course that includes a question interaction with Record interactions enabled
2. Publish course with the updated Spoor extension and ensure Record interactions is enabled
3. Upload to a LMS that does not have cmi.interactions._count functionality included
4. No error should appear




