### PR TITLE
fix: Adding a pagehide listener to cover bases when unload becomes deprecated

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -114,7 +114,7 @@ export default class StatefulSession extends Backbone.Controller {
     if (shouldCommitOnVisibilityChange) {
       document.addEventListener('visibilitychange', this.onVisibilityChange);
     }
-    $(window).on('beforeunload unload', this.endSession);
+    $(window).on('beforeunload unload pagehide', this.endSession);
   }
 
   async saveSessionState() {
@@ -261,7 +261,7 @@ export default class StatefulSession extends Backbone.Controller {
   }
 
   removeEventListeners() {
-    $(window).off('beforeunload unload', this.endSession);
+    $(window).off('beforeunload unload pagehide', this.endSession);
     document.removeEventListener('visibilitychange', this.onVisibilityChange);
     this.stopListening();
   }

--- a/required/log_output.html
+++ b/required/log_output.html
@@ -52,7 +52,7 @@
     </script>
   </head>
 
-  <body onload="onLoad();" onunload="onUnload();">
+  <body onload="onLoad();" onunload="onUnload();" onpagehide="onUnload();">
     <div id="logDiv"></div>
   </body>
 


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Partly fixes [FW3481](https://github.com/adaptlearning/adapt_framework/issues/3481)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Added a 'pagehide' listener to backup the soon-to-be-deprecated 'unload' event