### PR TITLE
Fix: delay error messaging until all course data is ready

### DIFF
--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -517,61 +517,59 @@ class ScormWrapper {
   async handleInitializeError() {
     if (!Data.isReady) await Data.whenReady();
     Adapt.trigger('tracking:initializeError');
-    // defer error to allow other plugins which may be handling errors to execute
-    _.defer(() => this.handleError(new ScormError(CLIENT_COULD_NOT_CONNECT)));
+    this.handleError(new ScormError(CLIENT_COULD_NOT_CONNECT));
   }
 
-  handleConnectionError(callback = null) {
+  async handleConnectionError(callback = null) {
+    if (!Data.isReady) await Data.whenReady();
     Adapt.trigger('tracking:connectionError', callback);
     this.handleError(new ScormError(CLIENT_NOT_CONNECTED));
   }
 
-  handleDataError(error) {
+  async handleDataError(error) {
+    if (!Data.isReady) await Data.whenReady();
     Adapt.trigger('tracking:dataError');
     this.handleError(error);
   }
 
-  handleFinishError(error) {
+  async handleFinishError(error) {
+    if (!Data.isReady) await Data.whenReady();
     Adapt.trigger('tracking:terminationError');
     this.handleError(error);
   }
 
-  handleError(error) {
-    if ('value' in error.data) {
-      // because some browsers (e.g. Firefox) don't like displaying very long strings in the window.confirm dialog
-      if (error.data.value.length && error.data.value.length > 80) error.data.value = error.data.value.slice(0, 80) + '...';
-      // if the value being set is an empty string, ensure it displays in the error as ''
-      if (error.data.value === '') error.data.value = '\'\'';
-    }
-
-    if (!Adapt.course) return;
-
-    const config = Adapt.course.get('_spoor');
-    const messages = Object.assign({}, ScormError.defaultMessages, config && config._messages);
-    const message = Handlebars.compile(messages[error.name])(error.data);
-
-    switch (error.name) {
-      case CLIENT_COULD_NOT_CONNECT:
-        // don't show if error notification already handled by other plugins
-        if (!Notify.isOpen) {
-          // prevent course load execution
-          Wait.begin();
-          router.hideLoading();
-
-          Notify.popup({
-            _isCancellable: false,
-            title: messages.title,
-            body: message
-          });
-        }
-    }
-
-    this.logger.error(message);
-
-    if (!this.suppressErrors && (!this.logOutputWin || this.logOutputWin.closed) && confirm(`${messages.title}:\n\n${message}\n\n${messages.pressOk}`)) {
-      this.showDebugWindow();
-    }
-
+  async handleError(error) {
+    if (!Data.isReady) await Data.whenReady();
+    // defer error to allow other plugins which may be handling errors to execute first
+    _.defer(() => {
+      if ('value' in error.data) {
+        // because some browsers (e.g. Firefox) don't like displaying very long strings in the window.confirm dialog
+        if (error.data.value.length && error.data.value.length > 80) error.data.value = error.data.value.slice(0, 80) + '...';
+        // if the value being set is an empty string, ensure it displays in the error as ''
+        if (error.data.value === '') error.data.value = '\'\'';
+      }
+      const config = Adapt.course.get('_spoor');
+      const messages = Object.assign({}, ScormError.defaultMessages, config && config._messages);
+      const message = Handlebars.compile(messages[error.name])(error.data);
+      switch (error.name) {
+        case CLIENT_COULD_NOT_CONNECT:
+          // don't show if error notification already handled by other plugins
+          if (!Notify.isOpen) {
+            // prevent course load execution
+            Wait.begin();
+            router.hideLoading();
+            Notify.popup({
+              _isCancellable: false,
+              title: messages.title,
+              body: message
+            });
+          }
+      }
+      this.logger.error(message);
+      if (!this.suppressErrors && (!this.logOutputWin || this.logOutputWin.closed) && confirm(`${messages.title}:\n\n${message}\n\n${messages.pressOk}`)) {
+        this.showDebugWindow();
+      }
+    });
   }
 
   recordScore(cmiPrefix, score, minScore = 0, maxScore = 100, isPercentageBased = true) {


### PR DESCRIPTION
Fixes #300, #283.

### Fix
* Delay error messaging until all course data is ready.
* Allows other plugins handling errors to listen to error events before they have been fired.


