### PR TITLE
Fix: Issue/299

### DIFF
--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -548,7 +548,7 @@ class ScormWrapper {
         // if the value being set is an empty string, ensure it displays in the error as ''
         if (error.data.value === '') error.data.value = '\'\'';
       }
-      const config = Adapt.course.get('_spoor');
+      const config = Adapt.course.get('_elfh_spoor') || {};
       const defaultMessages = ScormError.defaultMessages;
       const configMessages = config?.['_messages'] || {};
       const messages = Object.assign({}, defaultMessages, configMessages);

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -547,7 +547,9 @@ class ScormWrapper {
     if (!Adapt.course) return;
 
     const config = Adapt.course.get('_spoor');
-    const messages = Object.assign({}, ScormError.defaultMessages, config && config._messages);
+    const defaultMessages = ScormError.defaultMessages;
+    const configMessages = config?.['_messages'] || {};
+    const messages = Object.assign({}, defaultMessages, configMessages);
     const message = Handlebars.compile(messages[error.name])(error.data);
 
     switch (error.name) {

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -548,7 +548,7 @@ class ScormWrapper {
         // if the value being set is an empty string, ensure it displays in the error as ''
         if (error.data.value === '') error.data.value = '\'\'';
       }
-      const config = Adapt.course.get('_elfh_spoor') || {};
+      const config = Adapt.course.get('_spoor') || {};
       const defaultMessages = ScormError.defaultMessages;
       const configMessages = config?.['_messages'] || {};
       const messages = Object.assign({}, defaultMessages, configMessages);


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-spoor/issues/299

### Fix
If no custom error messages had been added then course.json will not contain a reference to "_spoor" and resulted in a script error and the course hanging on the loading screen

This appears to be the same issue mentioned in https://github.com/adaptlearning/adapt-contrib-spoor/issues/283 

