### PR TITLE
Fix: set html lang and dir attributes from config.json (fixes #499)

### DIFF
--- a/required/index.html
+++ b/required/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html id="adapt" class="no-js" lang="en" dir="ltr">
+<html id="adapt" class="no-js" lang="@@config._defaultLanguage" dir="@@config._defaultDirection">
   <head>
     <script>
       window.ADAPT_BUILD_TYPE = '@@build.type';

--- a/required/index_lms.html
+++ b/required/index_lms.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html id="adapt" class="no-js" lang="en" dir="ltr">
+<html id="adapt" class="no-js" lang="@@config._defaultLanguage" dir="@@config._defaultDirection">
   <head>
     <script>
       window.ADAPT_BUILD_TYPE = '@@build.type';

--- a/required/scorm_test_harness.html
+++ b/required/scorm_test_harness.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html id="adapt" class="no-js" lang="en" dir="ltr">
+<html id="adapt" class="no-js" lang="@@config._defaultLanguage" dir="@@config._defaultDirection">
   <head>
     <script>
       window.ADAPT_BUILD_TYPE = '@@build.type';


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-core/issues/499

### Fix
* Set initial html lang and dir attributes from _defaultLanguage and _defaultDirection in config.json
