### PR TITLE
Fix: Add pagehide event (Fixes #314)

### DIFF
--- a/js/adapt-stateful-session.js
+++ b/js/adapt-stateful-session.js
@@ -90,7 +90,7 @@ define([
 
     // Session In Progress
     setupEventListeners: function() {
-      $(window).on('beforeunload unload', this._onWindowUnload);
+      $(window).on('beforeunload unload pagehide', this._onWindowUnload);
 
       if (this._shouldStoreResponses) {
         this.listenTo(Adapt.components, 'change:_isInteractionComplete', this.onQuestionComponentComplete);
@@ -109,7 +109,7 @@ define([
     },
 
     removeEventListeners: function () {
-      $(window).off('beforeunload unload', this._onWindowUnload);
+      $(window).off('beforeunload unload pagehide', this._onWindowUnload);
       this.stopListening();
     },
 

--- a/required/log_output.html
+++ b/required/log_output.html
@@ -52,7 +52,7 @@
     </script>
   </head>
 
-  <body onload="onLoad();" onunload="onUnload();">
+  <body onload="onLoad();" onunload="onUnload();" onpagehide="onUnload();">
     <div id="logDiv"></div>
   </body>
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-spoor/issues/314

### Fix
Added the pagehide event next to the unload event with the same behaviour so that end-users won't notice when Google Chrome stops supporting unload. This is the same fix as was applied in the latest version of Spoor https://github.com/adaptlearning/adapt-contrib-spoor/pull/298/files.

### Testing
To test this I tried removing the unload events entirely and switching to pagehide events. I created and published a course and I was able to see that my progress was saved if I closed the window part-way through.

### Note
I'm not sure if there is a process for updating an older version of a plugin like this. I created a release-3.3 branch from the v3.3.2 tag. I have made a pull request to add this fix to the release-3.3 branch and I propose we tag v3.3.3 from the release-3.3 branch. I'm open to other suggestions if this isn't the way this is normally done in Adapt.

