### PR TITLE
Fix: SCORM 2004 runtime data reset if disconnected on exit

### DIFF
--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -169,6 +169,7 @@ class ScormWrapper {
 
     this.startTime = new Date();
     this.initTimedCommit();
+    this.setExitState();
     return this.lmsConnected;
   }
 
@@ -289,6 +290,8 @@ class ScormWrapper {
       return;
     }
 
+    this.setSessionTime();
+
     if (this.scorm.save()) {
       this.commitRetries = 0;
       this.lastCommitSuccessTime = new Date();
@@ -335,15 +338,8 @@ class ScormWrapper {
       this.logOutputWin.close();
     }
 
-    this.endTime = new Date();
-
-    if (this.isSCORM2004()) {
-      this.scorm.set('cmi.session_time', this.convertToSCORM2004Time(this.endTime.getTime() - this.startTime.getTime()));
-      this.scorm.set('cmi.exit', this.getExitState());
-    } else {
-      this.scorm.set('cmi.core.session_time', this.convertToSCORM12Time(this.endTime.getTime() - this.startTime.getTime()));
-      this.scorm.set('cmi.core.exit', this.getExitState());
-    }
+    this.setSessionTime();
+    this.setExitState();
 
     if (this._connection) {
       this._connection.stop();
@@ -940,6 +936,15 @@ class ScormWrapper {
     return response.join(',');
   }
 
+  setSessionTime() {
+    const endTime = new Date();
+    if (this.isSCORM2004()) {
+      this.setValue('cmi.session_time', this.convertToSCORM2004Time(endTime.getTime() - this.startTime.getTime()));
+    } else {
+      this.setValue('cmi.core.session_time', this.convertToSCORM12Time(endTime.getTime() - this.startTime.getTime()));
+    }
+  }
+
   getExitState() {
     const completionStatus = this.scorm.data.completionStatus;
     const isIncomplete = completionStatus === COMPLETION_STATE.INCOMPLETE.asLowerCase || completionStatus === COMPLETION_STATE.UNKNOWN.asLowerCase;
@@ -947,6 +952,11 @@ class ScormWrapper {
     if (exitState !== 'auto') return exitState;
     if (this.isSCORM2004()) return (isIncomplete ? 'suspend' : 'normal');
     return '';
+  }
+
+  setExitState() {
+    const dataModel = this.isSCORM2004() ? 'cmi.exit' : 'cmi.core.exit';
+    this.setValue(dataModel, this.getExitState());
   }
 
 }

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -940,9 +940,9 @@ class ScormWrapper {
     const endTime = new Date();
     if (this.isSCORM2004()) {
       this.setValue('cmi.session_time', this.convertToSCORM2004Time(endTime.getTime() - this.startTime.getTime()));
-    } else {
-      this.setValue('cmi.core.session_time', this.convertToSCORM12Time(endTime.getTime() - this.startTime.getTime()));
+      return;
     }
+    this.setValue('cmi.core.session_time', this.convertToSCORM12Time(endTime.getTime() - this.startTime.getTime()));
   }
 
   getExitState() {

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -955,8 +955,8 @@ class ScormWrapper {
   }
 
   setExitState() {
-    const dataModel = this.isSCORM2004() ? 'cmi.exit' : 'cmi.core.exit';
-    this.setValue(dataModel, this.getExitState());
+    const property = this.isSCORM2004() ? 'cmi.exit' : 'cmi.core.exit';
+    this.setValue(property, this.getExitState());
   }
 
 }


### PR DESCRIPTION
Fixes #320.

### Fix
*  Set exit state on initialisation to negate SCORM 2004 runtime data being reset on relaunch if disconnected whilst course window is closed.
* Set session time on each commit to prevent this from potentially being lost if [`finish`](https://github.com/adaptlearning/adapt-contrib-spoor/blob/9dbfaff2ee86abb394304c8471fef80d8e09ee2e/js/scorm/wrapper.js#L315) is not called during exit. This can occur due to being disconnected, or potentially when used via a mobile app which may not trigger the required [window events](https://github.com/adaptlearning/adapt-contrib-spoor/blob/9dbfaff2ee86abb394304c8471fef80d8e09ee2e/js/adapt-stateful-session.js#L129).