### PR TITLE
Fix: remove unwanted `imsss:objectives` from manifest

### DIFF
--- a/scorm/2004/imsmanifest.xml
+++ b/scorm/2004/imsmanifest.xml
@@ -14,9 +14,6 @@
             <item identifier="I_A001" identifierref="A001">
                 <title><![CDATA[@@course.title]]></title>
                 <imsss:sequencing>
-                    <imsss:objectives>
-                        <imsss:primaryObjective satisfiedByMeasure="false" objectiveID="Results" />
-                    </imsss:objectives>
                     <imsss:deliveryControls completionSetByContent="true" objectiveSetByContent="true" />
                 </imsss:sequencing>
                 <adlnav:presentation>


### PR DESCRIPTION
Fixes #322.

### Fix
* Remove unwanted `imsss:objectives` from manifest.


