### PR TITLE
Fix: send session time and exit state during call to finish

### DIFF
--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -323,6 +323,8 @@ class ScormWrapper {
       return;
     }
 
+    this.setSessionTime();
+    this.setExitState();
     this.finishCalled = true;
 
     if (this.timedCommitIntervalID !== null) {
@@ -337,9 +339,6 @@ class ScormWrapper {
     if (this.logOutputWin && !this.logOutputWin.closed) {
       this.logOutputWin.close();
     }
-
-    this.setSessionTime();
-    this.setExitState();
 
     if (this._connection) {
       this._connection.stop();


### PR DESCRIPTION
Fixes #334

### Fix
* Send session time and exit state during call to finish. Not recorded on exit since https://github.com/adaptlearning/adapt-contrib-spoor/releases/tag/v5.9.10.


