### PR TITLE
New: Use build.timestamp to force css reload

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-spoor",
   "version": "5.11.0",
-  "framework": ">=5.31.31",
+  "framework": ">=5.46.8",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-spoor/issues",
   "extension": "spoor",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "5.11.0",
+  "version": "5.11.4",
   "framework": ">=5.46.8",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-spoor/issues",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-spoor",
   "version": "5.11.0",
-  "framework": ">=5.31.31",
+  "framework": ">=5.46.8",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-spoor/issues",
   "extension": "spoor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-spoor",
-  "version": "5.11.0",
+  "version": "5.11.4",
   "framework": ">=5.46.8",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-spoor",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-spoor/issues",

--- a/required/index.html
+++ b/required/index.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="adapt.css" type="text/css" rel="stylesheet">
+    <link href="adapt.css?timestamp=@@build.timestamp" type="text/css" rel="stylesheet">
     <script src="libraries/modernizr.js"></script>
     <script src="adapt/js/scriptLoader.js"></script>
   </head>

--- a/required/index_lms.html
+++ b/required/index_lms.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="adapt.css" type="text/css" rel="stylesheet">
+    <link href="adapt.css?timestamp=@@build.timestamp" type="text/css" rel="stylesheet">
     <script src="libraries/modernizr.js"></script>
     <script src="adapt/js/scriptLoader.js"></script>
   </head>

--- a/required/scorm_test_harness.html
+++ b/required/scorm_test_harness.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="adapt.css" type="text/css" rel="stylesheet">
+    <link href="adapt.css?timestamp=@@build.timestamp" type="text/css" rel="stylesheet">
     <script src="libraries/modernizr.js"></script>
     <script src="adapt/js/scriptLoader.js"></script>
   </head>


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3649
requires  https://github.com/adaptlearning/adapt_framework/pull/3650
requires https://github.com/adaptlearning/adapt-contrib-core/pull/622

### New
* Force fresh css according to `@@build.timestamp`