### PR TITLE
Fix: Resetting location via an empty string may be ignored in SCORM 2004

### DIFF
--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -246,10 +246,12 @@ class ScormWrapper {
   }
 
   getLessonLocation() {
-    return this.getValue(this.isSCORM2004() ? 'cmi.location' : 'cmi.core.lesson_location');
+    const location = this.getValue(this.isSCORM2004() ? 'cmi.location' : 'cmi.core.lesson_location');
+    return location === 'null' ? '' : location;
   }
 
   setLessonLocation(location) {
+    if (location.trim() === '') location = 'null';
     this.setValue(this.isSCORM2004() ? 'cmi.location' : 'cmi.core.lesson_location', location);
   }
 

--- a/js/scorm/wrapper.js
+++ b/js/scorm/wrapper.js
@@ -251,7 +251,7 @@ class ScormWrapper {
   }
 
   setLessonLocation(location) {
-    if (location.trim() === '') location = 'null';
+    if (!location?.trim()) location = 'null';
     this.setValue(this.isSCORM2004() ? 'cmi.location' : 'cmi.core.lesson_location', location);
   }
 


### PR DESCRIPTION
Fixes #344.

### Fix
* Resetting location via an empty string may be ignored in SCORM 2004 - replaced with "null".


