### PR TITLE
Fix: Add production hardening

### DIFF
--- a/js/adapt-contrib-spoor.js
+++ b/js/adapt-contrib-spoor.js
@@ -5,6 +5,7 @@ import OfflineStorage from './adapt-offlineStorage-scorm';
 import offlineStorage from 'core/js/offlineStorage';
 import { shouldStart as shouldStartCookieLMS, start as startCookieLMS } from './scorm/cookieLMS';
 import 'libraries/jquery.keycombo';
+import './fixes/harden';
 
 class Spoor extends Backbone.Controller {
 

--- a/js/fixes/harden.js
+++ b/js/fixes/harden.js
@@ -8,7 +8,7 @@ import Adapt from 'core/js/adapt';
 Adapt.on('adapt:start', () => {
   const config = Adapt.config.get('_fixes');
   if (config?._harden !== true) return;
-  if (window.ADAPT_BUILD_TYPE !== 'development') return;
+  if (window.ADAPT_BUILD_TYPE === 'development') return;
   applyHarden();
 });
 

--- a/js/fixes/harden.js
+++ b/js/fixes/harden.js
@@ -1,0 +1,30 @@
+import Adapt from 'core/js/adapt';
+
+/**
+  Prevent the user from accessing SCORM API when
+  config.json:_fixes._harden = true and in production mode
+ */
+
+Adapt.on('adapt:start', () => {
+  const config = Adapt.config.get('_fixes');
+  if (config?._harden !== true) return;
+  if (window.ADAPT_BUILD_TYPE !== 'development') return;
+  applyHarden();
+});
+
+function applyHarden() {
+  delete window.SCORMSuspendData;
+  let win = window;
+  let findAttempts = 0;
+  const findAttemptLimit = 500;
+  while ((!win.API && !win.API_1484_11) &&
+        (win.parent) &&
+        (win.parent !== win) &&
+        (findAttempts <= findAttemptLimit)) {
+    findAttempts++;
+    win = win.parent;
+  }
+  if (!win.API && !win.API_1484_11) return;
+  delete win.API;
+  delete win.API_1484_11;
+}


### PR DESCRIPTION
references https://github.com/adaptlearning/adapt_framework/issues/3722

### New
* Added the ability to harden the SCORM API in production

### Testing
* `config.json:_fixes._harden = true`
* Must be built with `grunt build` or equivalent. 
* Must be loaded into an LMS.
* Check for `API` and `API_1484_11` in the console. Neither should be accessible.
